### PR TITLE
build(oci): copy license into container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,9 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ma
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .
+
+RUN mkdir /licenses
+COPY LICENSE /licenses/
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
Copies the license into a directory expected by our build pipeline.