### PR TITLE
ci(dependabot): add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: daily
+    labels:
+      - "dependencies"
+      - "chore"
+    open-pull-requests-limit: 20
+    ignore:
+      - dependency-name: k8s.io/*
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: sigs.k8s.io/*
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: github.com/openshift/api
+      - dependency-name: github.com/onsi/*
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Add a Dependabot configuration to keep Kubernetes dependencies up-to-date without breaking compatibility.