### PR TITLE
build(konflux): make build hermetic and prefetch deps

### DIFF
--- a/.tekton/runtimes-inventory-operator-pull-request.yaml
+++ b/.tekton/runtimes-inventory-operator-pull-request.yaml
@@ -96,11 +96,11 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: ""
+    - default: "true"
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/runtimes-inventory-operator-push.yaml
+++ b/.tekton/runtimes-inventory-operator-push.yaml
@@ -93,11 +93,11 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: ""
+    - default: "true"
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string


### PR DESCRIPTION
Set the hermetic and prefetch-input parameters to true to solve a couple of failures with the Enterprise Contract tests:
https://enterprisecontract.dev/docs/ec-policies/release_policy.html