### PR TITLE
build(csv): add supported arch/os labels

### DIFF
--- a/bundle/manifests/runtimes-inventory-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/runtimes-inventory-operator.clusterserviceversion.yaml
@@ -4,9 +4,15 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2024-03-25T19:00:02Z"
+    createdAt: "2024-08-28T13:37:54Z"
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
+    operatorframework.io/os.linux: supported
   name: runtimes-inventory-operator.v0.0.1-dev
   namespace: placeholder
 spec:

--- a/config/manifests/bases/runtimes-inventory-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/runtimes-inventory-operator.clusterserviceversion.yaml
@@ -4,6 +4,12 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
+    operatorframework.io/os.linux: supported
   name: runtimes-inventory-operator.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
While we just use the OLM bundle for testing purposes for now, it should be installable on all 4 architectures. This PR adds the necessary labels for that.