### PR TITLE
feat(test): support test pull secret

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,6 +23,7 @@ import (
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 
+	"github.com/RedHatInsights/runtimes-inventory-operator/internal/common"
 	"github.com/RedHatInsights/runtimes-inventory-operator/pkg/insights"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
@@ -111,8 +112,8 @@ func main() {
 				// in addition to any secret in the operator's namespace
 				&corev1.Secret{}: {
 					Namespaces: map[string]cache.Config{
-						"openshift-config": {
-							FieldSelector: fields.OneTermEqualSelector("metadata.name", "pull-secret"),
+						common.PullSecretNamespace: {
+							FieldSelector: fields.OneTermEqualSelector("metadata.name", common.PullSecretName),
 						},
 						operatorNamespace: {},
 					},

--- a/internal/common/constants.go
+++ b/internal/common/constants.go
@@ -23,6 +23,7 @@ const (
 	EnvInsightsBackendDomain = "INSIGHTS_BACKEND_DOMAIN"
 	EnvInsightsProxyDomain   = "INSIGHTS_PROXY_DOMAIN"
 	EnvInsightsEnabled       = "INSIGHTS_ENABLED"
+	EnvTestPullSecretName    = "INSIGHTS_TEST_PULL_SECRET_NAME"
 	// Environment variable to override the Insights proxy image
 	EnvInsightsProxyImageTag = "RELATED_IMAGE_INSIGHTS_PROXY"
 )

--- a/internal/common/constants.go
+++ b/internal/common/constants.go
@@ -20,6 +20,8 @@ const (
 	ProxyServiceName         = ProxyDeploymentName
 	ProxyServicePort         = 8080
 	ProxySecretName          = "apicastconf"
+	PullSecretName           = "pull-secret"
+	PullSecretNamespace      = "openshift-config"
 	EnvInsightsBackendDomain = "INSIGHTS_BACKEND_DOMAIN"
 	EnvInsightsProxyDomain   = "INSIGHTS_PROXY_DOMAIN"
 	EnvInsightsEnabled       = "INSIGHTS_ENABLED"

--- a/internal/controller/insights.go
+++ b/internal/controller/insights.go
@@ -120,7 +120,16 @@ func (r *InsightsReconciler) reconcileProxyService(ctx context.Context) error {
 func (r *InsightsReconciler) getTokenFromPullSecret(ctx context.Context) (*string, error) {
 	// Get the global pull secret
 	pullSecret := &corev1.Secret{}
-	err := r.Client.Get(ctx, types.NamespacedName{Namespace: "openshift-config", Name: "pull-secret"}, pullSecret)
+
+	var pullSecretName = "pull-secret"
+	var pullSecretNamespace = "openshift-config"
+
+	if len(r.testPullSecretName) > 0 {
+		pullSecretName = r.testPullSecretName
+		pullSecretNamespace = r.Namespace
+	}
+
+	err := r.Client.Get(ctx, types.NamespacedName{Namespace: pullSecretNamespace, Name: pullSecretName}, pullSecret)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controller/insights.go
+++ b/internal/controller/insights.go
@@ -120,16 +120,7 @@ func (r *InsightsReconciler) reconcileProxyService(ctx context.Context) error {
 func (r *InsightsReconciler) getTokenFromPullSecret(ctx context.Context) (*string, error) {
 	// Get the global pull secret
 	pullSecret := &corev1.Secret{}
-
-	var pullSecretName = "pull-secret"
-	var pullSecretNamespace = "openshift-config"
-
-	if len(r.testPullSecretName) > 0 {
-		pullSecretName = r.testPullSecretName
-		pullSecretNamespace = r.Namespace
-	}
-
-	err := r.Client.Get(ctx, types.NamespacedName{Namespace: pullSecretNamespace, Name: pullSecretName}, pullSecret)
+	err := r.Client.Get(ctx, types.NamespacedName{Namespace: r.pullSecretObj.Namespace, Name: r.pullSecretObj.Name}, pullSecret)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controller/insights_controller.go
+++ b/internal/controller/insights_controller.go
@@ -35,9 +35,10 @@ import (
 // InsightsReconciler reconciles the Insights proxy for Cryostat agents
 type InsightsReconciler struct {
 	*InsightsReconcilerConfig
-	backendDomain string
-	proxyDomain   string
-	proxyImageTag string
+	backendDomain      string
+	proxyDomain        string
+	proxyImageTag      string
+	testPullSecretName string
 }
 
 // InsightsReconcilerConfig contains configuration to create an InsightsReconciler
@@ -61,12 +62,15 @@ func NewInsightsReconciler(config *InsightsReconcilerConfig) (*InsightsReconcile
 		return nil, errors.New("no proxy image tag provided for Insights")
 	}
 	proxyDomain := config.GetEnv(common.EnvInsightsProxyDomain)
+	// the pull secret might be empty
+	testPullSecret := config.GetEnv(common.EnvTestPullSecretName)
 
 	return &InsightsReconciler{
 		InsightsReconcilerConfig: config,
 		backendDomain:            backendDomain,
 		proxyDomain:              proxyDomain,
 		proxyImageTag:            imageTag,
+		testPullSecretName:       testPullSecret,
 	}, nil
 }
 

--- a/internal/controller/insights_controller_unit_test.go
+++ b/internal/controller/insights_controller_unit_test.go
@@ -102,6 +102,19 @@ var _ = Describe("InsightsController", func() {
 				result := t.controller.isPullSecretOrProxyConfig(context.Background(), secret)
 				Expect(result).To(BeEmpty())
 			})
+			Context("with a test pull secret", func() {
+				BeforeEach(func() {
+					t.EnvTestPullSecret = &t.NewTestPullSecret().Name
+				})
+				It("should reconcile test pull secret", func() {
+					result := t.controller.isPullSecretOrProxyConfig(context.Background(), t.NewTestPullSecret())
+					Expect(result).To(ConsistOf(t.deploymentReconcileRequest()))
+				})
+				It("should not reconcile global pull secret", func() {
+					result := t.controller.isPullSecretOrProxyConfig(context.Background(), t.NewGlobalPullSecret())
+					Expect(result).To(BeEmpty())
+				})
+			})
 		})
 
 		Context("for deployments", func() {

--- a/internal/controller/test/utils.go
+++ b/internal/controller/test/utils.go
@@ -24,6 +24,7 @@ type TestUtilsConfig struct {
 	EnvInsightsProxyImageTag *string
 	EnvInsightsBackendDomain *string
 	EnvInsightsProxyDomain   *string
+	EnvTestPullSecret        *string
 }
 
 type testOSUtils struct {
@@ -43,6 +44,9 @@ func NewTestOSUtils(config *TestUtilsConfig) *testOSUtils {
 	}
 	if config.EnvInsightsProxyDomain != nil {
 		envs["INSIGHTS_PROXY_DOMAIN"] = *config.EnvInsightsProxyDomain
+	}
+	if config.EnvTestPullSecret != nil {
+		envs["INSIGHTS_TEST_PULL_SECRET_NAME"] = *config.EnvTestPullSecret
 	}
 	return &testOSUtils{envs: envs}
 }


### PR DESCRIPTION
This PR builds off of Attila's work in #19. By providing the name of a secret local to the operator's namespace in `INSIGHTS_TEST_PULL_SECRET_NAME`, the operator will reconcile that secret and use it to configure APICast instead of the global pull secret. This is entirely a testing aid where we may want to use different credentials than are present in the global pull secret of the test cluster.