### PR TITLE
fix(controller): append a unique suffix to avoid name conflicts

### DIFF
--- a/internal/common/common_utils.go
+++ b/internal/common/common_utils.go
@@ -15,6 +15,8 @@
 package common
 
 import (
+	"fmt"
+	"hash/fnv"
 	"os"
 
 	corev1 "k8s.io/api/core/v1"
@@ -53,6 +55,14 @@ func MergeLabelsAndAnnotations(dest *metav1.ObjectMeta, srcLabels, srcAnnotation
 	for k, v := range srcAnnotations {
 		dest.Annotations[k] = v
 	}
+}
+
+// NamespaceUniqueName appends a hash of the provided suffix to the name.
+func NamespaceUniqueName(name string, suffixToHash string) string {
+	// Use the 128-bit FNV-1 checksum of the suffix.
+	hash := fnv.New128()
+	hash.Write([]byte(suffixToHash))
+	return fmt.Sprintf("%s-%x", name, hash.Sum([]byte{}))
 }
 
 // SeccompProfile returns a SeccompProfile for the restricted

--- a/internal/common/constants.go
+++ b/internal/common/constants.go
@@ -15,14 +15,14 @@
 package common
 
 const (
-	InsightsConfigMapName    = "insights-proxy"
-	ProxyDeploymentName      = InsightsConfigMapName
-	ProxyServiceName         = ProxyDeploymentName
-	ProxyServicePort         = 8080
-	ProxySecretName          = "apicastconf"
-	EnvInsightsBackendDomain = "INSIGHTS_BACKEND_DOMAIN"
-	EnvInsightsProxyDomain   = "INSIGHTS_PROXY_DOMAIN"
-	EnvInsightsEnabled       = "INSIGHTS_ENABLED"
+	InsightsConfigMapNamePrefix = "insights-proxy"
+	ProxyDeploymentNamePrefix   = InsightsConfigMapNamePrefix
+	ProxyServiceNamePrefix      = ProxyDeploymentNamePrefix
+	ProxyServicePort            = 8080
+	ProxySecretNamePrefix       = "apicastconf"
+	EnvInsightsBackendDomain    = "INSIGHTS_BACKEND_DOMAIN"
+	EnvInsightsProxyDomain      = "INSIGHTS_PROXY_DOMAIN"
+	EnvInsightsEnabled          = "INSIGHTS_ENABLED"
 	// Environment variable to override the Insights proxy image
 	EnvInsightsProxyImageTag = "RELATED_IMAGE_INSIGHTS_PROXY"
 )

--- a/internal/common/naming.go
+++ b/internal/common/naming.go
@@ -1,0 +1,31 @@
+// Copyright Red Hat.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+func ProxyDeploymentName(operatorName string) string {
+	return NamespaceUniqueName(ProxyDeploymentNamePrefix, operatorName)
+}
+
+func ProxyServiceName(operatorName string) string {
+	return NamespaceUniqueName(ProxyServiceNamePrefix, operatorName)
+}
+
+func ProxySecretName(operatorName string) string {
+	return NamespaceUniqueName(ProxySecretNamePrefix, operatorName)
+}
+
+func InsightsConfigMapName(operatorName string) string {
+	return NamespaceUniqueName(InsightsConfigMapNamePrefix, operatorName)
+}

--- a/internal/controller/insights_controller.go
+++ b/internal/controller/insights_controller.go
@@ -47,6 +47,7 @@ type InsightsReconcilerConfig struct {
 	Scheme          *runtime.Scheme
 	Namespace       string
 	UserAgentPrefix string
+	OperatorName    string
 	common.OSUtils
 }
 
@@ -106,27 +107,27 @@ func (r *InsightsReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 func (r *InsightsReconciler) isPullSecretOrProxyConfig(ctx context.Context, secret client.Object) []reconcile.Request {
 	if !(secret.GetNamespace() == "openshift-config" && secret.GetName() == "pull-secret") &&
-		!(secret.GetNamespace() == r.Namespace && secret.GetName() == common.ProxySecretName) {
+		!(secret.GetNamespace() == r.Namespace && secret.GetName() == common.ProxySecretName(r.OperatorName)) {
 		return nil
 	}
 	return r.proxyDeploymentRequest()
 }
 
 func (r *InsightsReconciler) isProxyDeployment(ctx context.Context, deploy client.Object) []reconcile.Request {
-	if deploy.GetNamespace() != r.Namespace || deploy.GetName() != common.ProxyDeploymentName {
+	if deploy.GetNamespace() != r.Namespace || deploy.GetName() != common.ProxyDeploymentName(r.OperatorName) {
 		return nil
 	}
 	return r.proxyDeploymentRequest()
 }
 
 func (r *InsightsReconciler) isProxyService(ctx context.Context, svc client.Object) []reconcile.Request {
-	if svc.GetNamespace() != r.Namespace || svc.GetName() != common.ProxyServiceName {
+	if svc.GetNamespace() != r.Namespace || svc.GetName() != common.ProxyServiceName(r.OperatorName) {
 		return nil
 	}
 	return r.proxyDeploymentRequest()
 }
 
 func (r *InsightsReconciler) proxyDeploymentRequest() []reconcile.Request {
-	req := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: r.Namespace, Name: common.ProxyDeploymentName}}
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: r.Namespace, Name: common.ProxyDeploymentName(r.OperatorName)}}
 	return []reconcile.Request{req}
 }

--- a/internal/controller/insights_controller_test.go
+++ b/internal/controller/insights_controller_test.go
@@ -91,6 +91,7 @@ var _ = Describe("InsightsController", func() {
 				Log:             logger,
 				Namespace:       t.Namespace,
 				UserAgentPrefix: t.UserAgentPrefix,
+				OperatorName:    t.NewOperatorDeployment().Name,
 				OSUtils:         test.NewTestOSUtils(t.TestUtilsConfig),
 			}
 			controller, err := controller.NewInsightsReconciler(config)

--- a/internal/controller/insights_controller_unit_test.go
+++ b/internal/controller/insights_controller_unit_test.go
@@ -72,11 +72,12 @@ var _ = Describe("InsightsController", func() {
 			t.client = fake.NewClientBuilder().WithScheme(s).WithObjects(t.objs...).Build()
 
 			config := &InsightsReconcilerConfig{
-				Client:    t.client,
-				Scheme:    s,
-				Log:       logger,
-				Namespace: t.Namespace,
-				OSUtils:   test.NewTestOSUtils(t.TestUtilsConfig),
+				Client:       t.client,
+				Scheme:       s,
+				Log:          logger,
+				Namespace:    t.Namespace,
+				OperatorName: t.NewOperatorDeployment().Name,
+				OSUtils:      test.NewTestOSUtils(t.TestUtilsConfig),
 			}
 			controller, err := NewInsightsReconciler(config)
 			Expect(err).ToNot(HaveOccurred())
@@ -141,5 +142,5 @@ var _ = Describe("InsightsController", func() {
 })
 
 func (t *insightsUnitTestInput) deploymentReconcileRequest() reconcile.Request {
-	return reconcile.Request{NamespacedName: types.NamespacedName{Name: "insights-proxy", Namespace: t.Namespace}}
+	return reconcile.Request{NamespacedName: types.NamespacedName{Name: t.NewInsightsProxyDeployment().Name, Namespace: t.Namespace}}
 }

--- a/internal/controller/test/resources.go
+++ b/internal/controller/test/resources.go
@@ -55,7 +55,7 @@ func (r *InsightsTestResources) NewGlobalPullSecret() *corev1.Secret {
 func (r *InsightsTestResources) NewOperatorDeployment() *appsv1.Deployment {
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-controller-manager",
+			Name:      "test-operator",
 			Namespace: r.Namespace,
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -83,10 +83,13 @@ func (r *InsightsTestResources) NewOperatorDeployment() *appsv1.Deployment {
 	}
 }
 
+// FNV-1 128-bit hash of "test-operator"
+const suffix = "c3f06a36e4abd94b849f4d1f07e29cfe"
+
 func (r *InsightsTestResources) NewProxyConfigMap() *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "insights-proxy",
+			Name:      "insights-proxy-" + suffix,
 			Namespace: r.Namespace,
 		},
 	}
@@ -95,7 +98,7 @@ func (r *InsightsTestResources) NewProxyConfigMap() *corev1.ConfigMap {
 func (r *InsightsTestResources) NewInsightsProxySecret() *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "apicastconf",
+			Name:      "apicastconf-" + suffix,
 			Namespace: r.Namespace,
 		},
 		StringData: map[string]string{
@@ -105,7 +108,7 @@ func (r *InsightsTestResources) NewInsightsProxySecret() *corev1.Secret {
 					"id": "1",
 					"backend_version": "1",
 					"proxy": {
-					  "hosts": ["insights-proxy","insights-proxy.%s.svc.cluster.local"],
+					  "hosts": ["insights-proxy-%s","insights-proxy-%s.%s.svc"],
 					  "api_backend": "https://insights.example.com:443/",
 					  "backend": { "endpoint": "http://127.0.0.1:8081", "host": "backend" },
 					  "policy_chain": [
@@ -154,7 +157,7 @@ func (r *InsightsTestResources) NewInsightsProxySecret() *corev1.Secret {
 					}
 				  }
 				]
-			  }`, r.Namespace, r.UserAgentPrefix),
+			  }`, suffix, suffix, r.Namespace, r.UserAgentPrefix),
 		},
 	}
 }
@@ -162,7 +165,7 @@ func (r *InsightsTestResources) NewInsightsProxySecret() *corev1.Secret {
 func (r *InsightsTestResources) NewInsightsProxySecretWithProxyDomain() *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "apicastconf",
+			Name:      "apicastconf-" + suffix,
 			Namespace: r.Namespace,
 		},
 		StringData: map[string]string{
@@ -172,7 +175,7 @@ func (r *InsightsTestResources) NewInsightsProxySecretWithProxyDomain() *corev1.
 					"id": "1",
 					"backend_version": "1",
 					"proxy": {
-					  "hosts": ["insights-proxy","insights-proxy.%s.svc.cluster.local"],
+					  "hosts": ["insights-proxy-%s","insights-proxy-%s.%s.svc"],
 					  "api_backend": "https://insights.example.com:443/",
 					  "backend": { "endpoint": "http://127.0.0.1:8081", "host": "backend" },
 					  "policy_chain": [
@@ -228,7 +231,7 @@ func (r *InsightsTestResources) NewInsightsProxySecretWithProxyDomain() *corev1.
 					}
 				  }
 				]
-			  }`, r.Namespace, r.UserAgentPrefix),
+			  }`, suffix, suffix, r.Namespace, r.UserAgentPrefix),
 		},
 	}
 }
@@ -251,22 +254,22 @@ func (r *InsightsTestResources) NewInsightsProxyDeployment() *appsv1.Deployment 
 	}
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "insights-proxy",
+			Name:      "insights-proxy-" + suffix,
 			Namespace: r.Namespace,
 			Labels: map[string]string{
-				"app": "insights-proxy",
+				"app": "insights-proxy-" + suffix,
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"app": "insights-proxy",
+					"app": "insights-proxy-" + suffix,
 				},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"app": "insights-proxy",
+						"app": "insights-proxy-" + suffix,
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -346,7 +349,7 @@ func (r *InsightsTestResources) NewInsightsProxyDeployment() *appsv1.Deployment 
 							Name: "gateway-configuration-volume",
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									SecretName: "apicastconf",
+									SecretName: "apicastconf-" + suffix,
 									Items: []corev1.KeyToPath{
 										{
 											Key:  "config.json",
@@ -371,16 +374,16 @@ func (r *InsightsTestResources) NewInsightsProxyDeployment() *appsv1.Deployment 
 func (r *InsightsTestResources) NewInsightsProxyService() *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "insights-proxy",
+			Name:      "insights-proxy-" + suffix,
 			Namespace: r.Namespace,
 			Labels: map[string]string{
-				"app": "insights-proxy",
+				"app": "insights-proxy-" + suffix,
 			},
 		},
 		Spec: corev1.ServiceSpec{
 			Type: corev1.ServiceTypeClusterIP,
 			Selector: map[string]string{
-				"app": "insights-proxy",
+				"app": "insights-proxy-" + suffix,
 			},
 			Ports: []corev1.ServicePort{
 				{

--- a/pkg/insights/setup.go
+++ b/pkg/insights/setup.go
@@ -116,6 +116,7 @@ func (i *InsightsIntegration) createInsightsController() error {
 		Scheme:          i.Manager.GetScheme(),
 		Namespace:       i.opNamespace,
 		UserAgentPrefix: i.userAgentPrefix,
+		OperatorName:    i.opName,
 		OSUtils:         i.OSUtils,
 	}
 	controller, err := controller.NewInsightsReconciler(config)
@@ -140,7 +141,7 @@ func (i *InsightsIntegration) createConfigMap(ctx context.Context) error {
 
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      common.InsightsConfigMapName,
+			Name:      common.InsightsConfigMapName(i.opName),
 			Namespace: i.opNamespace,
 		},
 	}
@@ -161,7 +162,7 @@ func (i *InsightsIntegration) deleteConfigMap(ctx context.Context) error {
 	// Children will be garbage collected
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      common.InsightsConfigMapName,
+			Name:      common.InsightsConfigMapName(i.opName),
 			Namespace: i.opNamespace,
 		},
 	}
@@ -177,7 +178,7 @@ func (i *InsightsIntegration) deleteConfigMap(ctx context.Context) error {
 func (i *InsightsIntegration) getProxyURL() *url.URL {
 	return &url.URL{
 		Scheme: "http", // TODO add https support
-		Host: fmt.Sprintf("%s.%s.svc.cluster.local:%d", common.ProxyServiceName, i.opNamespace,
+		Host: fmt.Sprintf("%s.%s.svc.cluster.local:%d", common.ProxyServiceName(i.opName), i.opNamespace,
 			common.ProxyServicePort),
 	}
 }

--- a/pkg/insights/setup_test.go
+++ b/pkg/insights/setup_test.go
@@ -105,7 +105,7 @@ var _ = Describe("InsightsIntegration", func() {
 				result, err := t.integration.Setup()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).ToNot(BeNil())
-				Expect(result.String()).To(Equal(fmt.Sprintf("http://insights-proxy.%s.svc.cluster.local:8080", t.Namespace)))
+				Expect(result.String()).To(Equal(fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", t.NewInsightsProxyService().Name, t.Namespace)))
 			})
 
 			It("should create config map", func() {


### PR DESCRIPTION
This PR appends a 128-bit FNV-1 hash of the parent operator's name to any objects created by this controller. This ensures that two or more operators using this controller image in the same namespace do not attempt to create objects with the same name. I used FNV-1 since it is faster and shorter than something like SHA256, since we don't need a cryptographically secure hash, just one not likely to collide.

I also removed the `cluster.local` domain from the bind address of the APICast proxy. This is the default domain name of Kubernetes clusters, but it can be changed by administrators.

To test:
1. Install my build of this PR
    ```
    $ cat << 'EOF' | oc create -f -
    apiVersion: v1
    items:
    - apiVersion: apps/v1
      kind: Deployment
      metadata:
        labels:
          app: agent-test-quarkus
          app.kubernetes.io/component: agent-test-quarkus
          app.kubernetes.io/instance: agent-test-quarkus
        name: agent-test-quarkus
        namespace: openshift-operators
      spec:
        selector:
          matchLabels:
            deployment: agent-test-quarkus
        template:
          metadata:
            labels:
              deployment: agent-test-quarkus
          spec:
            containers:
            - env:
              - name: APP_NAME
                valueFrom:
                  fieldRef:
                    apiVersion: v1
                    fieldPath: metadata.name
              - name: JAVA_OPTS_APPEND
                value: -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -javaagent:/usr/share/runtimes-agent/runtimes-agent.jar=name=$(APP_NAME);is_ocp=true;token=dummy;debug=true;base_url=http://insights-proxy-e5fd6ee28fff69527527e104c7f00b29.openshift-operators.svc:8080
              image: quay.io/ebaron/quarkus-test:latest
              imagePullPolicy: Always
              name: agent-test-quarkus
              ports:
              - containerPort: 8080
                protocol: TCP
              - containerPort: 8443
                protocol: TCP
              resources: {}
              securityContext:
                allowPrivilegeEscalation: false
                capabilities:
                  drop:
                  - ALL
              volumeMounts:
              - mountPath: /usr/share/runtimes-agent/
                name: shared-data
            initContainers:
            - command:
              - cp
              - /agent/runtimes-agent.jar
              - /usr/share/runtimes-agent/
              image: quay.io/ebaron/runtimes-agent-init:1.0.3
              imagePullPolicy: Always
              name: download-agent
              securityContext:
                allowPrivilegeEscalation: false
                capabilities:
                  drop:
                  - ALL
              volumeMounts:
              - mountPath: /usr/share/runtimes-agent/
                name: shared-data
            securityContext:
              runAsNonRoot: true
              seccompProfile:
                type: RuntimeDefault
            volumes:
            - emptyDir: {}
              name: shared-data
    - apiVersion: operators.coreos.com/v1alpha1
      kind: CatalogSource
      metadata:
        name: runtimes-inventory-catalog
        namespace: openshift-marketplace
      spec:
        displayName: Runtimes Inventory Catalog
        image: quay.io/ebaron/runtimes-inventory-operator-catalog:suffix-01
        publisher: grpc
        sourceType: grpc
    - apiVersion: operators.coreos.com/v1alpha1
      kind: Subscription
      metadata:
        name: runtimes-inventory-operator
        namespace: openshift-operators
      spec:
        channel: alpha
        name: runtimes-inventory-operator
        source: runtimes-inventory-catalog
        sourceNamespace: openshift-marketplace
    kind: List
    metadata: {}
    EOF
    ```
2. Check that the operator creates a `insights-proxy-e5fd6ee28fff69527527e104c7f00b29` deployment in `openshift-operators`, and wait for that deployment to become ready
3. Restart the application deployment:
    ```
    $ oc rollout restart deploy agent-test-quarkus
    ```
4. Check that the report was received:
    ```
    $ oc logs deploy/agent-test-quarkus | grep Payload
    2025-04-10 17:30:08:751 +0000 [pool-1-thread-1] DEBUG com.redhat.insights.agent.AgentLogger - Red Hat Insights - Payload was accepted for processing
    ```