### PR TITLE
feat(arch): enable running on arm64 clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ customer.
 
 ### Environment Variables
 The following are required environment variables your operator must set:
-- `RELATED_IMAGE_INSIGHTS_PROXY`: the container image to be used for the APICast proxy (e.g. `registry.redhat.io/3scale-amp2/apicast-gateway-rhel8:3scale2.14`)
+- `RELATED_IMAGE_INSIGHTS_PROXY`: the container image to be used for the APICast proxy (e.g. `registry.redhat.io/3scale-amp2/apicast-gateway-rhel8:3scale2.15`)
 - `INSIGHTS_BACKEND_DOMAIN`: the Red Hat Insights server host where reports will be forwarded (e.g. `console.redhat.com`)
 - `INSIGHTS_ENABLED`: must be set to `true` in order for this component to run, this provides an opt-out mechanism for customers at the operator level
 

--- a/bundle/manifests/runtimes-inventory-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/runtimes-inventory-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2025-04-11T16:09:01Z"
+    createdAt: "2025-04-14T14:14:55Z"
     operators.operatorframework.io/builder: operator-sdk-v1.39.2
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   labels:
@@ -99,7 +99,7 @@ spec:
                 - name: INSIGHTS_BACKEND_DOMAIN
                   value: console.redhat.com
                 - name: RELATED_IMAGE_INSIGHTS_PROXY
-                  value: registry.redhat.io/3scale-amp2/apicast-gateway-rhel8:3scale2.14
+                  value: registry.redhat.io/3scale-amp2/apicast-gateway-rhel8:3scale2.15
                 - name: USER_AGENT_PREFIX
                   value: cryostat-operator/0.0.0
                 image: controller:latest
@@ -227,6 +227,6 @@ spec:
     name: Red Hat
     url: https://www.redhat.com
   relatedImages:
-  - image: registry.redhat.io/3scale-amp2/apicast-gateway-rhel8:3scale2.14
+  - image: registry.redhat.io/3scale-amp2/apicast-gateway-rhel8:3scale2.15
     name: insights-proxy
   version: 0.0.1-dev

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,9 +16,7 @@ package main
 import (
 	"crypto/tls"
 	"flag"
-	"fmt"
 	"os"
-	"runtime"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -176,17 +174,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	// TODO APICast is not currently available for arm64, disable it for now
-	if runtime.GOARCH == "arm64" {
-		setupLog.Info(fmt.Sprintf("Insights proxy unavailable for %s. Skipping setup", runtime.GOARCH))
+	insightsURL, err := insights.NewInsightsIntegration(mgr,
+		operatorName, operatorNamespace, userAgentPrefix, &setupLog).Setup()
+	if err != nil {
+		setupLog.Error(err, "failed to set up Insights integration")
 	} else {
-		insightsURL, err := insights.NewInsightsIntegration(mgr,
-			operatorName, operatorNamespace, userAgentPrefix, &setupLog).Setup()
-		if err != nil {
-			setupLog.Error(err, "failed to set up Insights integration")
-		} else {
-			setupLog.Info("Insights proxy set up", "url", insightsURL.String())
-		}
+		setupLog.Info("Insights proxy set up", "url", insightsURL.String())
 	}
 
 	//+kubebuilder:scaffold:builder

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -84,7 +84,7 @@ spec:
         - name: INSIGHTS_BACKEND_DOMAIN
           value: console.redhat.com
         - name: RELATED_IMAGE_INSIGHTS_PROXY
-          value: registry.redhat.io/3scale-amp2/apicast-gateway-rhel8:3scale2.14
+          value: registry.redhat.io/3scale-amp2/apicast-gateway-rhel8:3scale2.15
         # FIXME temp
         - name: USER_AGENT_PREFIX
           value: cryostat-operator/0.0.0


### PR DESCRIPTION
This PR removes the conditional that effectively disabled the operator when running on an arm64 cluster. It also bumps the APICast version from 2.14 to 2.15, which includes arm64 support.

Assuming you are logged into an arm64 OpenShift cluster, you can test this PR as follows:
1. Install the operator using my build of this PR
    ```
    $ cat << 'EOF' | oc create -f -
    apiVersion: v1
    items:
    - apiVersion: apps/v1
      kind: Deployment
      metadata:
        labels:
          app: agent-test-quarkus
          app.kubernetes.io/component: agent-test-quarkus
          app.kubernetes.io/instance: agent-test-quarkus
        name: agent-test-quarkus
        namespace: openshift-operators
      spec:
        selector:
          matchLabels:
            deployment: agent-test-quarkus
        template:
          metadata:
            labels:
              deployment: agent-test-quarkus
          spec:
            containers:
            - env:
              - name: APP_NAME
                valueFrom:
                  fieldRef:
                    apiVersion: v1
                    fieldPath: metadata.name
              - name: JAVA_OPTS_APPEND
                value: -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -javaagent:/usr/share/runtimes-agent/runtimes-agent.jar=name=$(APP_NAME);is_ocp=true;token=dummy;debug=true;base_url=http://insights-proxy-e5fd6ee28fff69527527e104c7f00b29.openshift-operators.svc:8080
              image: quay.io/redhat-java-monitoring/quarkus-cryostat-agent:latest
              imagePullPolicy: Always
              name: agent-test-quarkus
              ports:
              - containerPort: 8080
                protocol: TCP
              - containerPort: 8443
                protocol: TCP
              resources: {}
              securityContext:
                allowPrivilegeEscalation: false
                capabilities:
                  drop:
                  - ALL
              volumeMounts:
              - mountPath: /usr/share/runtimes-agent/
                name: shared-data
            initContainers:
            - command:
              - cp
              - /agent/runtimes-agent.jar
              - /usr/share/runtimes-agent/
              image: quay.io/ebaron/runtimes-agent-init:1.0.3
              imagePullPolicy: Always
              name: download-agent
              securityContext:
                allowPrivilegeEscalation: false
                capabilities:
                  drop:
                  - ALL
              volumeMounts:
              - mountPath: /usr/share/runtimes-agent/
                name: shared-data
            securityContext:
              runAsNonRoot: true
              seccompProfile:
                type: RuntimeDefault
            volumes:
            - emptyDir: {}
              name: shared-data
    - apiVersion: operators.coreos.com/v1alpha1
      kind: CatalogSource
      metadata:
        name: runtimes-inventory-catalog
        namespace: openshift-marketplace
      spec:
        displayName: Runtimes Inventory Catalog
        image: quay.io/ebaron/runtimes-inventory-operator-catalog:arm64-01
        publisher: grpc
        sourceType: grpc
    - apiVersion: operators.coreos.com/v1alpha1
      kind: Subscription
      metadata:
        name: runtimes-inventory-operator
        namespace: openshift-operators
      spec:
        channel: alpha
        name: runtimes-inventory-operator
        source: runtimes-inventory-catalog
        sourceNamespace: openshift-marketplace
    kind: List
    metadata: {}
    EOF
    ```
2. Check that the operator creates a `insights-proxy-e5fd6ee28fff69527527e104c7f00b29` deployment in `openshift-operators`, and wait for that deployment to become ready
3. Restart the application deployment:
    ```
    $ oc rollout restart deploy agent-test-quarkus
    ```
4. Check that the report was received:
    ```
    $ oc logs deploy/agent-test-quarkus | grep Payload
    2025-04-10 17:30:08:751 +0000 [pool-1-thread-1] DEBUG com.redhat.insights.agent.AgentLogger - Red Hat Insights - Payload was accepted for processing
    ```