### PR TITLE
feat(webhook): add pod mutation webhook to inject agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ COPY cmd/main.go cmd/main.go
 # COPY api/ api/
 COPY internal/controller/ internal/controller/
 COPY internal/common/ internal/common/
+COPY internal/webhooks/ internal/webhooks/
 COPY pkg/ pkg/
 
 # Build

--- a/Makefile
+++ b/Makefile
@@ -310,3 +310,16 @@ catalog-build: opm ## Build a catalog image.
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
+
+# cert-manager helpers for development
+CERT_MANAGER_VERSION ?= 1.12.14
+CERT_MANAGER_MANIFEST ?= \
+	https://github.com/cert-manager/cert-manager/releases/download/v$(CERT_MANAGER_VERSION)/cert-manager.yaml
+
+.PHONY: cert_manager
+cert_manager: remove_cert_manager ## Install cert manager.
+	$(KUBECTL) create --validate=false -f $(CERT_MANAGER_MANIFEST)
+
+.PHONY: remove_cert_manager
+remove_cert_manager: ## Remove cert manager.
+	- $(KUBECTL) delete --ignore-not-found=true -f $(CERT_MANAGER_MANIFEST)

--- a/bundle/manifests/runtimes-inventory-operator-webhook-service_v1_service.yaml
+++ b/bundle/manifests/runtimes-inventory-operator-webhook-service_v1_service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/created-by: runtimes-inventory-operator
+    app.kubernetes.io/instance: webhook-service
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: runtimes-inventory-operator
+    app.kubernetes.io/part-of: runtimes-inventory-operator
+  name: runtimes-inventory-operator-webhook-service
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app.kubernetes.io/name: runtimes-inventory-operator
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/bundle/manifests/runtimes-inventory-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/runtimes-inventory-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2025-04-14T14:14:55Z"
+    createdAt: "2025-06-19T18:51:28Z"
     operators.operatorframework.io/builder: operator-sdk-v1.39.2
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   labels:
@@ -110,6 +110,10 @@ spec:
                   initialDelaySeconds: 15
                   periodSeconds: 20
                 name: manager
+                ports:
+                - containerPort: 9443
+                  name: webhook-server
+                  protocol: TCP
                 readinessProbe:
                   httpGet:
                     path: /readyz
@@ -128,10 +132,19 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                volumeMounts:
+                - mountPath: /tmp/k8s-webhook-server/serving-certs
+                  name: cert
+                  readOnly: true
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: runtimes-inventory-operator-controller-manager
               terminationGracePeriodSeconds: 10
+              volumes:
+              - name: cert
+                secret:
+                  defaultMode: 420
+                  secretName: webhook-server-cert
       permissions:
       - rules:
         - apiGroups:
@@ -230,3 +243,27 @@ spec:
   - image: registry.redhat.io/3scale-amp2/apicast-gateway-rhel8:3scale2.15
     name: insights-proxy
   version: 0.0.1-dev
+  webhookdefinitions:
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: runtimes-inventory-operator-controller-manager
+    failurePolicy: Ignore
+    generateName: mpod.runtimes.insights.redhat.com
+    objectSelector:
+      matchExpressions:
+      - key: com.redhat.insights.runtimes/inject-agent
+        operator: Exists
+    rules:
+    - apiGroups:
+      - ""
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      resources:
+      - pods
+    sideEffects: None
+    targetPort: 9443
+    type: MutatingAdmissionWebhook
+    webhookPath: /mutate--v1-pod

--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -1,0 +1,25 @@
+# The following manifests contain a self-signed issuer CR and a certificate CR.
+# More document can be found at https://docs.cert-manager.io
+# WARNING: Targets CertManager v1.0. Check https://cert-manager.io/docs/installation/upgrading/ for breaking changes.
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: system
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
+  namespace: system
+spec:
+  # $(SERVICE_NAME) and $(SERVICE_NAMESPACE) will be substituted by kustomize
+  dnsNames:
+  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
+  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: webhook-server-cert # this secret will not be prefixed, since it's not managed by kustomize

--- a/config/certmanager/kustomization.yaml
+++ b/config/certmanager/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+- certificate.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/config/certmanager/kustomizeconfig.yaml
+++ b/config/certmanager/kustomizeconfig.yaml
@@ -1,0 +1,16 @@
+# This configuration is for teaching kustomize how to update name ref and var substitution 
+nameReference:
+- kind: Issuer
+  group: cert-manager.io
+  fieldSpecs:
+  - kind: Certificate
+    group: cert-manager.io
+    path: spec/issuerRef/name
+
+varReference:
+- kind: Certificate
+  group: cert-manager.io
+  path: spec/commonName
+- kind: Certificate
+  group: cert-manager.io
+  path: spec/dnsNames

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -21,9 +21,9 @@ resources:
 - ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- ../webhook
+- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
-#- ../certmanager
+- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 # [METRICS] Expose the controller manager metrics service.
@@ -44,109 +44,110 @@ patches:
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- path: manager_webhook_patch.yaml
+- path: manager_webhook_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
-#- path: webhookcainjection_patch.yaml
+- path: webhookcainjection_patch.yaml
+- path: webhook_object_selector_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
 # Uncomment the following replacements to add the cert-manager CA injection annotations
-#replacements:
-#  - source: # Add cert-manager annotation to ValidatingWebhookConfiguration, MutatingWebhookConfiguration and CRDs
-#      kind: Certificate
-#      group: cert-manager.io
-#      version: v1
-#      name: serving-cert # this name should match the one in certificate.yaml
-#      fieldPath: .metadata.namespace # namespace of the certificate CR
-#    targets:
-#      - select:
-#          kind: ValidatingWebhookConfiguration
-#        fieldPaths:
-#          - .metadata.annotations.[cert-manager.io/inject-ca-from]
-#        options:
-#          delimiter: '/'
-#          index: 0
-#          create: true
-#      - select:
-#          kind: MutatingWebhookConfiguration
-#        fieldPaths:
-#          - .metadata.annotations.[cert-manager.io/inject-ca-from]
-#        options:
-#          delimiter: '/'
-#          index: 0
-#          create: true
-#      - select:
-#          kind: CustomResourceDefinition
-#        fieldPaths:
-#          - .metadata.annotations.[cert-manager.io/inject-ca-from]
-#        options:
-#          delimiter: '/'
-#          index: 0
-#          create: true
-#  - source:
-#      kind: Certificate
-#      group: cert-manager.io
-#      version: v1
-#      name: serving-cert # this name should match the one in certificate.yaml
-#      fieldPath: .metadata.name
-#    targets:
-#      - select:
-#          kind: ValidatingWebhookConfiguration
-#        fieldPaths:
-#          - .metadata.annotations.[cert-manager.io/inject-ca-from]
-#        options:
-#          delimiter: '/'
-#          index: 1
-#          create: true
-#      - select:
-#          kind: MutatingWebhookConfiguration
-#        fieldPaths:
-#          - .metadata.annotations.[cert-manager.io/inject-ca-from]
-#        options:
-#          delimiter: '/'
-#          index: 1
-#          create: true
-#      - select:
-#          kind: CustomResourceDefinition
-#        fieldPaths:
-#          - .metadata.annotations.[cert-manager.io/inject-ca-from]
-#        options:
-#          delimiter: '/'
-#          index: 1
-#          create: true
-#  - source: # Add cert-manager annotation to the webhook Service
-#      kind: Service
-#      version: v1
-#      name: webhook-service
-#      fieldPath: .metadata.name # namespace of the service
-#    targets:
-#      - select:
-#          kind: Certificate
-#          group: cert-manager.io
-#          version: v1
-#        fieldPaths:
-#          - .spec.dnsNames.0
-#          - .spec.dnsNames.1
-#        options:
-#          delimiter: '.'
-#          index: 0
-#          create: true
-#  - source:
-#      kind: Service
-#      version: v1
-#      name: webhook-service
-#      fieldPath: .metadata.namespace # namespace of the service
-#    targets:
-#      - select:
-#          kind: Certificate
-#          group: cert-manager.io
-#          version: v1
-#        fieldPaths:
-#          - .spec.dnsNames.0
-#          - .spec.dnsNames.1
-#        options:
-#          delimiter: '.'
-#          index: 1
-#          create: true
+replacements:
+ - source: # Add cert-manager annotation to ValidatingWebhookConfiguration, MutatingWebhookConfiguration and CRDs
+     kind: Certificate
+     group: cert-manager.io
+     version: v1
+     name: serving-cert # this name should match the one in certificate.yaml
+     fieldPath: .metadata.namespace # namespace of the certificate CR
+   targets:
+     - select:
+         kind: ValidatingWebhookConfiguration
+       fieldPaths:
+         - .metadata.annotations.[cert-manager.io/inject-ca-from]
+       options:
+         delimiter: '/'
+         index: 0
+         create: true
+     - select:
+         kind: MutatingWebhookConfiguration
+       fieldPaths:
+         - .metadata.annotations.[cert-manager.io/inject-ca-from]
+       options:
+         delimiter: '/'
+         index: 0
+         create: true
+     - select:
+         kind: CustomResourceDefinition
+       fieldPaths:
+         - .metadata.annotations.[cert-manager.io/inject-ca-from]
+       options:
+         delimiter: '/'
+         index: 0
+         create: true
+ - source:
+     kind: Certificate
+     group: cert-manager.io
+     version: v1
+     name: serving-cert # this name should match the one in certificate.yaml
+     fieldPath: .metadata.name
+   targets:
+     - select:
+         kind: ValidatingWebhookConfiguration
+       fieldPaths:
+         - .metadata.annotations.[cert-manager.io/inject-ca-from]
+       options:
+         delimiter: '/'
+         index: 1
+         create: true
+     - select:
+         kind: MutatingWebhookConfiguration
+       fieldPaths:
+         - .metadata.annotations.[cert-manager.io/inject-ca-from]
+       options:
+         delimiter: '/'
+         index: 1
+         create: true
+     - select:
+         kind: CustomResourceDefinition
+       fieldPaths:
+         - .metadata.annotations.[cert-manager.io/inject-ca-from]
+       options:
+         delimiter: '/'
+         index: 1
+         create: true
+ - source: # Add cert-manager annotation to the webhook Service
+     kind: Service
+     version: v1
+     name: webhook-service
+     fieldPath: .metadata.name # namespace of the service
+   targets:
+     - select:
+         kind: Certificate
+         group: cert-manager.io
+         version: v1
+       fieldPaths:
+         - .spec.dnsNames.0
+         - .spec.dnsNames.1
+       options:
+         delimiter: '.'
+         index: 0
+         create: true
+ - source:
+     kind: Service
+     version: v1
+     name: webhook-service
+     fieldPath: .metadata.namespace # namespace of the service
+   targets:
+     - select:
+         kind: Certificate
+         group: cert-manager.io
+         version: v1
+       fieldPaths:
+         - .spec.dnsNames.0
+         - .spec.dnsNames.1
+       options:
+         delimiter: '.'
+         index: 1
+         create: true

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-cert

--- a/config/default/webhook_object_selector_patch.yaml
+++ b/config/default/webhook_object_selector_patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+webhooks:
+- name: mpod.runtimes.insights.redhat.com
+  objectSelector:
+    matchExpressions:
+      - key: com.redhat.insights.runtimes/inject-agent
+        operator: Exists

--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -1,0 +1,15 @@
+# This patch add annotation to admission webhook config and
+# the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/name: mutatingwebhookconfiguration
+    app.kubernetes.io/instance: mutating-webhook-configuration
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/created-by: runtimes-inventory-operator
+    app.kubernetes.io/part-of: runtimes-inventory-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- manifests.yaml
+- service.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/config/webhook/kustomizeconfig.yaml
+++ b/config/webhook/kustomizeconfig.yaml
@@ -1,0 +1,25 @@
+# the following config is for teaching kustomize where to look at when substituting vars.
+# It requires kustomize v2.1.0 or newer to work properly.
+nameReference:
+- kind: Service
+  version: v1
+  fieldSpecs:
+  - kind: MutatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+  - kind: ValidatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+
+namespace:
+- kind: MutatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true
+- kind: ValidatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true
+
+varReference:
+- path: metadata/annotations

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate--v1-pod
+  failurePolicy: Ignore
+  name: mpod.runtimes.insights.redhat.com
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -1,0 +1,20 @@
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: service
+    app.kubernetes.io/instance: webhook-service
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/created-by: runtimes-inventory-operator
+    app.kubernetes.io/part-of: runtimes-inventory-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: webhook-service
+  namespace: system
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    control-plane: controller-manager

--- a/internal/common/constants.go
+++ b/internal/common/constants.go
@@ -14,6 +14,10 @@
 
 package common
 
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
 const (
 	InsightsConfigMapNamePrefix = "insights-proxy"
 	ProxyDeploymentNamePrefix   = InsightsConfigMapNamePrefix
@@ -25,4 +29,7 @@ const (
 	EnvInsightsEnabled          = "INSIGHTS_ENABLED"
 	// Environment variable to override the Insights proxy image
 	EnvInsightsProxyImageTag = "RELATED_IMAGE_INSIGHTS_PROXY"
+	// ALL capability to drop for restricted pod security. See:
+	// https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
+	CapabilityAll corev1.Capability = "ALL"
 )

--- a/internal/controller/insights_controller.go
+++ b/internal/controller/insights_controller.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-// InsightsReconciler reconciles the Insights proxy for Cryostat agents
+// InsightsReconciler reconciles the Insights proxy for Runtimes agents
 type InsightsReconciler struct {
 	*InsightsReconcilerConfig
 	backendDomain string

--- a/internal/controller/test/expect.go
+++ b/internal/controller/test/expect.go
@@ -15,8 +15,6 @@
 package test
 
 import (
-	"fmt"
-
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -28,13 +26,14 @@ func ExpectResourceRequirements(containerResource, expectedResource *corev1.Reso
 	requestCpu, requestCpuFound := containerResource.Requests[corev1.ResourceCPU]
 	expectedRequestCpu := expectedResource.Requests[corev1.ResourceCPU]
 	gomega.Expect(requestCpuFound).To(gomega.BeTrue())
-	fmt.Printf("%+v\n%+v\n", containerResource.Requests, expectedResource.Requests)
-	gomega.Expect(requestCpu.Equal(expectedRequestCpu)).To(gomega.BeTrue())
+	gomega.Expect(requestCpu.Equal(expectedRequestCpu)).To(gomega.BeTrue(),
+		"expected CPU requests %s to equal %s", requestCpu.String(), expectedRequestCpu.String())
 
 	requestMemory, requestMemoryFound := containerResource.Requests[corev1.ResourceMemory]
 	expectedRequestMemory := expectedResource.Requests[corev1.ResourceMemory]
 	gomega.Expect(requestMemoryFound).To(gomega.BeTrue())
-	gomega.Expect(requestMemory.Equal(expectedRequestMemory)).To(gomega.BeTrue())
+	gomega.Expect(requestMemory.Equal(expectedRequestMemory)).To(gomega.BeTrue(),
+		"expected memory requests %s to equal %s", requestMemory.String(), expectedRequestMemory.String())
 
 	if expectedResource.Limits == nil {
 		gomega.Expect(containerResource.Limits).To(gomega.BeNil())
@@ -46,7 +45,8 @@ func ExpectResourceRequirements(containerResource, expectedResource *corev1.Reso
 
 		gomega.Expect(limitCpuFound).To(gomega.Equal(expectedLimitCpuFound))
 		if expectedLimitCpuFound {
-			gomega.Expect(limitCpu.Equal(expectedLimitCpu)).To(gomega.BeTrue())
+			gomega.Expect(limitCpu.Equal(expectedLimitCpu)).To(gomega.BeTrue(),
+				"expected CPU limit %s to equal %s", limitCpu.String(), expectedLimitCpu.String())
 		}
 
 		limitMemory, limitMemoryFound := containerResource.Limits[corev1.ResourceMemory]
@@ -54,7 +54,8 @@ func ExpectResourceRequirements(containerResource, expectedResource *corev1.Reso
 
 		gomega.Expect(limitMemoryFound).To(gomega.Equal(expectedLimitMemoryFound))
 		if expectedLimitCpuFound {
-			gomega.Expect(limitMemory.Equal(expectedlimitMemory)).To(gomega.BeTrue())
+			gomega.Expect(limitMemory.Equal(expectedlimitMemory)).To(gomega.BeTrue(),
+				"expected memory limit %s to equal %s", limitMemory.String(), expectedlimitMemory.String())
 		}
 	}
 }

--- a/internal/controller/test/utils.go
+++ b/internal/controller/test/utils.go
@@ -24,6 +24,7 @@ type TestUtilsConfig struct {
 	EnvInsightsProxyImageTag *string
 	EnvInsightsBackendDomain *string
 	EnvInsightsProxyDomain   *string
+	EnvAgentInitImageTag     *string
 }
 
 type testOSUtils struct {
@@ -44,6 +45,9 @@ func NewTestOSUtils(config *TestUtilsConfig) *testOSUtils {
 	if config.EnvInsightsProxyDomain != nil {
 		envs["INSIGHTS_PROXY_DOMAIN"] = *config.EnvInsightsProxyDomain
 	}
+	if config.EnvAgentInitImageTag != nil {
+		envs["RELATED_IMAGE_AGENT_INIT"] = *config.EnvAgentInitImageTag
+	}
 	return &testOSUtils{envs: envs}
 }
 
@@ -54,6 +58,14 @@ func (o *testOSUtils) GetFileContents(path string) ([]byte, error) {
 
 func (o *testOSUtils) GetEnv(name string) string {
 	return o.envs[name]
+}
+
+func (o *testOSUtils) GetEnvOrDefault(name string, defaultVal string) string {
+	val, pres := o.envs[name]
+	if pres {
+		return val
+	}
+	return defaultVal
 }
 
 func (o *testOSUtils) GenPasswd(length int) string {

--- a/internal/webhooks/pod_defaulter_test.go
+++ b/internal/webhooks/pod_defaulter_test.go
@@ -1,0 +1,334 @@
+// Copyright The Cryostat Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhooks_test
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/RedHatInsights/runtimes-inventory-operator/internal/common"
+	"github.com/RedHatInsights/runtimes-inventory-operator/internal/controller/test"
+	webhooktests "github.com/RedHatInsights/runtimes-inventory-operator/internal/webhooks/test"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+type defaulterTestInput struct {
+	client ctrlclient.Client
+	objs   []ctrlclient.Object
+	*webhooktests.AgentWebhookTestResources
+}
+
+var _ = Describe("PodDefaulter", func() {
+	var t *defaulterTestInput
+	count := 0
+
+	namespaceWithSuffix := func(name string) string {
+		return name + "-agent-" + strconv.Itoa(count)
+	}
+
+	BeforeEach(func() {
+		ns := namespaceWithSuffix("test")
+		t = &defaulterTestInput{
+			AgentWebhookTestResources: &webhooktests.AgentWebhookTestResources{
+				InsightsTestResources: &test.InsightsTestResources{
+					Namespace: ns,
+				},
+			},
+		}
+		t.objs = []ctrlclient.Object{
+			t.NewNamespace(),
+		}
+	})
+
+	JustBeforeEach(func() {
+		logger := zap.New()
+		logf.SetLogger(logger)
+
+		t.client = k8sClient
+		for _, obj := range t.objs {
+			err := t.client.Create(ctx, obj)
+			Expect(err).ToNot(HaveOccurred())
+		}
+	})
+
+	JustAfterEach(func() {
+		for _, obj := range t.objs {
+			err := ctrlclient.IgnoreNotFound(t.client.Delete(ctx, obj))
+			Expect(err).ToNot(HaveOccurred())
+		}
+	})
+
+	AfterEach(func() {
+		count++
+	})
+
+	Context("configuring a pod", func() {
+		var originalPod *corev1.Pod
+		var expectedPod *corev1.Pod
+
+		BeforeEach(func() {
+			svc := t.NewInsightsProxyService()
+			insightsURL, err := url.Parse(fmt.Sprintf("http://%s.%s.svc:8080", svc.Name, svc.Namespace))
+			Expect(err).ToNot(HaveOccurred())
+			agentWebhookConfig.InsightsURL = insightsURL
+		})
+
+		JustBeforeEach(func() {
+			err := t.client.Create(ctx, originalPod)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			agentWebhookConfig.InsightsURL = nil
+			originalPod = nil
+			expectedPod = nil
+		})
+
+		ExpectPod := func() {
+			It("should add init container", func() {
+				actual := t.getPod(expectedPod)
+				expectedInitContainers := expectedPod.Spec.InitContainers
+				Expect(actual.Spec.InitContainers).To(HaveLen(len(expectedInitContainers)))
+				for idx := range expectedInitContainers {
+					expected := expectedPod.Spec.InitContainers[idx]
+					container := actual.Spec.InitContainers[idx]
+					Expect(container.Name).To(Equal(expected.Name))
+					Expect(container.Command).To(Equal(expected.Command))
+					Expect(container.Args).To(Equal(expected.Args))
+					Expect(container.Env).To(Equal(expected.Env))
+					Expect(container.EnvFrom).To(Equal(expected.EnvFrom))
+					Expect(container.Image).To(HavePrefix(expected.Image[:strings.Index(expected.Image, ":")]))
+					Expect(container.VolumeMounts).To(Equal(expected.VolumeMounts))
+					Expect(container.SecurityContext).To(Equal(expected.SecurityContext))
+					Expect(container.Ports).To(Equal(expected.Ports))
+					Expect(container.LivenessProbe).To(Equal(expected.LivenessProbe))
+					Expect(container.ReadinessProbe).To(Equal(expected.ReadinessProbe))
+					test.ExpectResourceRequirements(&container.Resources, &expected.Resources)
+				}
+			})
+
+			It("should add volume(s)", func() {
+				actual := t.getPod(expectedPod)
+				Expect(actual.Spec.Volumes).To(ConsistOf(expectedPod.Spec.Volumes))
+			})
+
+			It("should add volume mounts(s)", func() {
+				actual := t.getPod(expectedPod)
+				Expect(actual.Spec.Containers).To(HaveLen(len(expectedPod.Spec.Containers)))
+				for i, expected := range expectedPod.Spec.Containers {
+					container := actual.Spec.Containers[i]
+					Expect(container.VolumeMounts).To(ConsistOf(expected.VolumeMounts))
+				}
+			})
+
+			It("should add environment variables", func() {
+				actual := t.getPod(expectedPod)
+				Expect(actual.Spec.Containers).To(HaveLen(len(expectedPod.Spec.Containers)))
+				for i, expected := range expectedPod.Spec.Containers {
+					container := actual.Spec.Containers[i]
+					Expect(container.Env).To(ConsistOf(expected.Env))
+					Expect(container.EnvFrom).To(ConsistOf(expected.EnvFrom))
+				}
+			})
+
+			It("should add ports(s)", func() {
+				actual := t.getPod(expectedPod)
+				Expect(actual.Spec.Containers).To(HaveLen(len(expectedPod.Spec.Containers)))
+				for i, expected := range expectedPod.Spec.Containers {
+					container := actual.Spec.Containers[i]
+					Expect(container.Ports).To(ConsistOf(expected.Ports))
+				}
+			})
+		}
+
+		Context("with defaults", func() {
+			BeforeEach(func() {
+				originalPod = t.NewPod()
+				expectedPod = t.NewMutatedPod()
+			})
+
+			ExpectPod()
+		})
+
+		Context("with existing JAVA_TOOL_OPTIONS", func() {
+			BeforeEach(func() {
+				originalPod = t.NewPodJavaToolOptions()
+				expectedPod = t.NewMutatedPodJavaToolOptions()
+			})
+
+			ExpectPod()
+		})
+
+		Context("with existing JAVA_TOOL_OPTIONS using valueFrom", func() {
+			BeforeEach(func() {
+				originalPod = t.NewPodJavaToolOptionsFrom()
+				// Should fail
+				expectedPod = originalPod
+			})
+
+			ExpectPod()
+		})
+
+		Context("with no inject label", func() {
+			BeforeEach(func() {
+				originalPod = t.NewPodNoInjectLabel()
+				// Should fail
+				expectedPod = originalPod
+			})
+
+			ExpectPod()
+		})
+
+		Context("with custom image tag", func() {
+			var saveOSUtils common.OSUtils
+
+			BeforeEach(func() {
+				originalPod = t.NewPod()
+			})
+
+			setImageTag := func(imageTag string) {
+				saveOSUtils = agentWebhookConfig.OSUtils
+				// Force webhook to query environment again
+				agentWebhookConfig.InitImageTag = nil
+				agentWebhookConfig.OSUtils = test.NewTestOSUtils(&test.TestUtilsConfig{
+					EnvAgentInitImageTag: &[]string{imageTag}[0],
+				})
+			}
+
+			JustAfterEach(func() {
+				// Reset state
+				agentWebhookConfig.OSUtils = saveOSUtils
+				agentWebhookConfig.InitImageTag = nil
+			})
+
+			Context("for development", func() {
+				BeforeEach(func() {
+					expectedPod = t.NewMutatedPodCustomDevImage()
+					setImageTag("example.com/agent-init:latest")
+				})
+
+				ExpectPod()
+
+				It("should use Always pull policy", func() {
+					actual := t.getPod(expectedPod)
+					expectedInitContainers := expectedPod.Spec.InitContainers
+					Expect(actual.Spec.InitContainers).To(HaveLen(len(expectedInitContainers)))
+					for idx := range expectedInitContainers {
+						container := actual.Spec.InitContainers[idx]
+						Expect(container.ImagePullPolicy).To(Equal(corev1.PullAlways))
+					}
+				})
+			})
+
+			Context("for release", func() {
+				BeforeEach(func() {
+					expectedPod = t.NewMutatedPodCustomImage()
+					setImageTag("example.com/agent-init:2.0.0")
+				})
+
+				ExpectPod()
+
+				It("should use IfNotPresent pull policy", func() {
+					actual := t.getPod(expectedPod)
+					expectedInitContainers := expectedPod.Spec.InitContainers
+					Expect(actual.Spec.InitContainers).To(HaveLen(len(expectedInitContainers)))
+					for idx := range expectedInitContainers {
+						container := actual.Spec.InitContainers[idx]
+						Expect(container.ImagePullPolicy).To(Equal(corev1.PullIfNotPresent))
+					}
+				})
+			})
+		})
+
+		Context("with a debug logging label", func() {
+			Context("enabled", func() {
+				BeforeEach(func() {
+					originalPod = t.NewPodLogDebugLabel()
+					expectedPod = t.NewMutatedPodLogDebugLabel()
+				})
+
+				ExpectPod()
+			})
+
+			Context("that is invalid", func() {
+				BeforeEach(func() {
+					originalPod = t.NewPodLogDebugLabelBad()
+					// Should fail
+					expectedPod = originalPod
+				})
+
+				ExpectPod()
+			})
+		})
+
+		Context("with multiple containers", func() {
+			BeforeEach(func() {
+				originalPod = t.NewPodMultiContainer()
+				expectedPod = t.NewMutatedPodMultiContainer()
+			})
+
+			ExpectPod()
+		})
+
+		Context("with a custom container label", func() {
+			Context("for a container that exists", func() {
+				BeforeEach(func() {
+					originalPod = t.NewPodContainerLabel()
+					expectedPod = t.NewMutatedPodContainerLabel()
+				})
+
+				ExpectPod()
+			})
+
+			Context("for a container that doesn't exist", func() {
+				BeforeEach(func() {
+					originalPod = t.NewPodContainerBadLabel()
+					// Should fail
+					expectedPod = originalPod
+				})
+
+				ExpectPod()
+			})
+		})
+
+		Context("with a custom java options var label", func() {
+			BeforeEach(func() {
+				originalPod = t.NewPodJavaOptsVar()
+				expectedPod = t.NewMutatedPodJavaOptsVarLabel()
+			})
+
+			ExpectPod()
+		})
+
+		// TODO Add test cases for custom resource requirements when implemented
+	})
+})
+
+func (t *defaulterTestInput) getPod(expected *corev1.Pod) *corev1.Pod {
+	pod := &corev1.Pod{}
+	err := t.client.Get(context.Background(), types.NamespacedName{Name: expected.Name, Namespace: expected.Namespace}, pod)
+	Expect(err).ToNot(HaveOccurred())
+	return pod
+}

--- a/internal/webhooks/pod_mutator.go
+++ b/internal/webhooks/pod_mutator.go
@@ -1,0 +1,264 @@
+// Copyright The Cryostat Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhooks
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/RedHatInsights/runtimes-inventory-operator/internal/common"
+)
+
+type podMutator struct {
+	client client.Client
+	log    *logr.Logger
+	config *AgentWebhookConfig
+}
+
+var _ admission.CustomDefaulter = &podMutator{}
+
+const (
+	agentLabelPrefix         = "com.redhat.insights.runtimes/"
+	agentLabelInjectAgent    = agentLabelPrefix + "inject-agent"
+	agentLabelContainer      = agentLabelPrefix + "container"
+	agentLabelJavaOptionsVar = agentLabelPrefix + "java-options-var"
+	agentLabelLogDebug       = agentLabelPrefix + "log-debug"
+
+	javaAgentParam           = "-javaagent"
+	agentPath                = "/tmp/rh-runtimes-insights/runtimes-agent.jar"
+	podNameEnvVar            = "RHT_INSIGHTS_JAVA_AGENT_POD_NAME"
+	podNamespaceEnvVar       = "RHT_INSIGHTS_JAVA_AGENT_POD_NAMESPACE"
+	defaultAgentInitImageTag = "quay.io/ebaron/runtimes-agent-init:latest" // FIXME
+	agentMaxSizeBytes        = "50Mi"
+	agentInitCpuRequest      = "10m"
+	agentInitMemoryRequest   = "32Mi"
+	defaultJavaOptsVar       = "JAVA_TOOL_OPTIONS"
+)
+
+// Default optionally mutates a pod to inject the Insights Java Agent
+func (r *podMutator) Default(ctx context.Context, obj runtime.Object) error {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return fmt.Errorf("expected a Pod, but received a %T", obj)
+	}
+	// Use GenerateName for logging if no explicit Name is given
+	podName := pod.Name
+	if len(podName) == 0 {
+		podName = pod.GenerateName
+	}
+	log := r.log.WithValues("name", podName, "namespace", pod.Namespace)
+
+	// Check for required label and return early if missing.
+	// This should not happen because such pods are filtered out by Kubernetes server-side due to our object selector.
+	if !metav1.HasLabel(pod.ObjectMeta, agentLabelInjectAgent) {
+		log.Info("pod is missing required label")
+		return nil
+	}
+
+	if !isOptionEnabled(pod.Labels, agentLabelInjectAgent) {
+		log.Info("agent injection is disabled")
+		return nil
+	}
+
+	// Select target container
+	container, err := getTargetContainer(pod)
+	if err != nil {
+		return err
+	}
+
+	// Add init container
+	nonRoot := true
+	imageTag := r.getImageTag()
+	pod.Spec.InitContainers = append(pod.Spec.InitContainers, corev1.Container{
+		Name:            "runtimes-agent-init",
+		Image:           imageTag,
+		ImagePullPolicy: common.GetPullPolicy(imageTag),
+		Command:         []string{"cp", "-v", "/agent/runtimes-agent.jar", "/tmp/rh-runtimes-insights/runtimes-agent.jar"},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      "runtimes-agent-init",
+				MountPath: "/tmp/rh-runtimes-insights",
+			},
+		},
+		SecurityContext: &corev1.SecurityContext{
+			RunAsNonRoot: &nonRoot,
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{
+					common.CapabilityAll,
+				},
+			},
+		},
+		Resources: *getResourceRequirements(),
+	})
+
+	// Add emptyDir volume to copy agent into, and mount it
+	sizeLimit := resource.MustParse(agentMaxSizeBytes)
+	pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+		Name: "runtimes-agent-init",
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{
+				SizeLimit: &sizeLimit,
+			},
+		},
+	})
+
+	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+		Name:      "runtimes-agent-init",
+		MountPath: "/tmp/rh-runtimes-insights",
+		ReadOnly:  true,
+	})
+
+	// Prepend these to the environment variable list so they can be
+	// referenced by a possibly existing java options variable
+	prependEnvs := []corev1.EnvVar{
+		{
+			Name: podNameEnvVar,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.name",
+				},
+			},
+		},
+		{
+			Name: podNamespaceEnvVar,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.namespace",
+				},
+			},
+		},
+	}
+	container.Env = append(prependEnvs, container.Env...)
+
+	// Inject agent using JAVA_TOOL_OPTIONS or specified variable, appending to any existing value
+	extended, err := r.extendJavaOptsVar(container.Env, getJavaOptionsVar(pod.Labels),
+		isOptionEnabled(pod.Labels, agentLabelLogDebug))
+	if err != nil {
+		return err
+	}
+	container.Env = extended
+
+	log.Info("configured Red Hat Insights for Runtimes agent for pod")
+	return nil
+}
+
+func getResourceRequirements() *corev1.ResourceRequirements {
+	resources := &corev1.ResourceRequirements{}
+	// TODO allow customization
+	common.PopulateResourceRequest(resources, agentInitCpuRequest, agentInitMemoryRequest)
+	return resources
+}
+
+func (r *podMutator) getImageTag() string {
+	// Lazily look up image tag
+	if r.config.InitImageTag == nil {
+		agentInitImage := r.config.GetEnvOrDefault(agentInitImageTagEnv, defaultAgentInitImageTag)
+		r.config.InitImageTag = &agentInitImage
+	}
+	return *r.config.InitImageTag
+}
+
+func getTargetContainer(pod *corev1.Pod) (*corev1.Container, error) {
+	if len(pod.Spec.Containers) == 0 {
+		// Should never happen, Kubernetes doesn't allow this
+		return nil, errors.New("pod has no containers")
+	}
+	label, pres := pod.Labels[agentLabelContainer]
+	if !pres {
+		// Use the first container by default
+		return &pod.Spec.Containers[0], nil
+	}
+	// Find the container matching the label
+	return findNamedContainer(pod.Spec.Containers, label)
+}
+
+func findNamedContainer(containers []corev1.Container, name string) (*corev1.Container, error) {
+	for i, container := range containers {
+		if container.Name == name {
+			return &containers[i], nil
+		}
+	}
+	return nil, fmt.Errorf("no container found with name \"%s\"", name)
+}
+
+func getJavaOptionsVar(labels map[string]string) string {
+	result := defaultJavaOptsVar
+	value, pres := labels[agentLabelJavaOptionsVar]
+	if pres {
+		result = value
+	}
+	return result
+}
+
+func (r *podMutator) extendJavaOptsVar(envs []corev1.EnvVar, javaOptsVar string, debugLogging bool) ([]corev1.EnvVar, error) {
+	existing, err := findJavaOptsVar(envs, javaOptsVar)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build agent config
+	config := []string{
+		newAgentArg("name", fmt.Sprintf("$(%s)", podNameEnvVar)),
+		newAgentArg("base_url", r.config.InsightsURL.String()),
+		newAgentArg("pod_name", fmt.Sprintf("$(%s)", podNameEnvVar)),
+		newAgentArg("pod_namespace", fmt.Sprintf("$(%s)", podNamespaceEnvVar)),
+		newAgentArg("token", "unused"),
+	}
+	// Add debug logging if specified
+	if debugLogging {
+		config = append(config, newAgentArg("debug", "true"))
+	}
+	agentArgLine := fmt.Sprintf("%s:'%s=%s'", javaAgentParam, agentPath, strings.Join(config, ";"))
+	if existing != nil {
+		existing.Value += " " + agentArgLine
+	} else {
+		envs = append(envs, corev1.EnvVar{
+			Name:  javaOptsVar,
+			Value: agentArgLine,
+		})
+	}
+
+	return envs, nil
+}
+
+func findJavaOptsVar(envs []corev1.EnvVar, javaOptsVar string) (*corev1.EnvVar, error) {
+	for i, env := range envs {
+		if env.Name == javaOptsVar {
+			if env.ValueFrom != nil {
+				return nil, fmt.Errorf("environment variable %s uses \"valueFrom\" and cannot be extended", javaOptsVar)
+			}
+			return &envs[i], nil
+		}
+	}
+	return nil, nil
+}
+
+func isOptionEnabled(labels map[string]string, key string) bool {
+	return strings.ToLower(labels[key]) == "true"
+}
+
+func newAgentArg(name string, value string) string {
+	return name + "=" + value
+}

--- a/internal/webhooks/pod_mutator.go
+++ b/internal/webhooks/pod_mutator.go
@@ -50,7 +50,7 @@ const (
 	agentPath                = "/tmp/rh-runtimes-insights/runtimes-agent.jar"
 	podNameEnvVar            = "RHT_INSIGHTS_JAVA_AGENT_POD_NAME"
 	podNamespaceEnvVar       = "RHT_INSIGHTS_JAVA_AGENT_POD_NAMESPACE"
-	defaultAgentInitImageTag = "quay.io/ebaron/runtimes-agent-init:latest" // FIXME
+	defaultAgentInitImageTag = "registry.redhat.io/insights-runtimes-tech-preview/runtimes-agent-init-rhel9:latest"
 	agentMaxSizeBytes        = "50Mi"
 	agentInitCpuRequest      = "10m"
 	agentInitMemoryRequest   = "32Mi"

--- a/internal/webhooks/pod_webhook.go
+++ b/internal/webhooks/pod_webhook.go
@@ -1,0 +1,99 @@
+// Copyright The Cryostat Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhooks
+
+import (
+	"context"
+	"net/url"
+
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/RedHatInsights/runtimes-inventory-operator/internal/common"
+)
+
+// podWebhookLog is for logging in this package.
+var podWebhookLog = logf.Log.WithName("pod-webhook")
+
+//+kubebuilder:webhook:path=/mutate--v1-pod,mutating=true,failurePolicy=ignore,sideEffects=None,groups="",resources=pods,verbs=create,versions=v1,name=mpod.runtimes.insights.redhat.com,admissionReviewVersions=v1
+
+// Environment variable to override the agent init container image
+const agentInitImageTagEnv = "RELATED_IMAGE_AGENT_INIT"
+
+type AgentWebhook interface {
+	SetupWebhookWithManager(mgr ctrl.Manager) error
+}
+
+type AgentWebhookConfig struct {
+	InitImageTag *string
+	InsightsURL  *url.URL
+	common.OSUtils
+}
+
+type agentWebhook struct {
+	*AgentWebhookConfig
+}
+
+var _ AgentWebhook = &agentWebhook{}
+
+func NewAgentWebhook(config *AgentWebhookConfig) AgentWebhook {
+	if config.OSUtils == nil {
+		config.OSUtils = &common.DefaultOSUtils{}
+	}
+	return &agentWebhook{
+		AgentWebhookConfig: config,
+	}
+}
+
+func (r *agentWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	webhook := admission.WithCustomDefaulter(mgr.GetScheme(), &corev1.Pod{}, &podMutator{
+		client: mgr.GetClient(),
+		config: r.AgentWebhookConfig,
+		log:    &podWebhookLog,
+	}).WithRecoverPanic(true)
+	// Modify the webhook to never deny the pod from being admitted
+	webhook.Handler = allowAllRequests(webhook.Handler)
+	mgr.GetWebhookServer().Register("/mutate--v1-pod", webhook)
+	return nil
+}
+
+type allowAllHandlerWrapper struct {
+	impl admission.Handler
+}
+
+func (r *allowAllHandlerWrapper) Handle(ctx context.Context, req admission.Request) admission.Response {
+	// Call the handler implementation
+	result := r.impl.Handle(ctx, req)
+	if !result.Allowed {
+		msg := ""
+		if result.Result != nil {
+			msg = result.Result.Message
+		}
+		podWebhookLog.Info("pod mutation failed", "result", msg)
+	}
+	// Modify the result to always permit the request
+	result.Allowed = true
+	return result
+}
+
+var _ admission.Handler = &allowAllHandlerWrapper{}
+
+func allowAllRequests(handler admission.Handler) admission.Handler {
+	return &allowAllHandlerWrapper{
+		impl: handler,
+	}
+}

--- a/internal/webhooks/test/resources.go
+++ b/internal/webhooks/test/resources.go
@@ -177,7 +177,7 @@ func (r *AgentWebhookTestResources) setDefaultMutatedPodOptions(options *mutated
 		options.namespace = r.Namespace
 	}
 	if len(options.image) == 0 {
-		options.image = "quay.io/ebaron/runtimes-agent-init:latest" // FIXME
+		options.image = "registry.redhat.io/insights-runtimes-tech-preview/runtimes-agent-init-rhel9:latest"
 	}
 	if len(options.pullPolicy) == 0 {
 		options.pullPolicy = corev1.PullAlways

--- a/internal/webhooks/test/resources.go
+++ b/internal/webhooks/test/resources.go
@@ -1,0 +1,378 @@
+// Copyright The Cryostat Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"fmt"
+
+	"github.com/RedHatInsights/runtimes-inventory-operator/internal/controller/test"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type AgentWebhookTestResources struct {
+	*test.InsightsTestResources
+}
+
+func (r *AgentWebhookTestResources) NewPod() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "insights-agent-webhook-test",
+			Namespace: r.Namespace,
+			Labels: map[string]string{
+				"com.redhat.insights.runtimes/inject-agent": "true",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "test",
+					Image: "example.com/test:latest",
+					Env: []corev1.EnvVar{
+						{
+							Name:  "TEST",
+							Value: "some-value",
+						},
+					},
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: &[]bool{false}[0],
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{
+								"ALL",
+							},
+						},
+					},
+				},
+			},
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot: &[]bool{true}[0],
+			},
+		},
+	}
+}
+
+func (r *AgentWebhookTestResources) NewPodMultiContainer() *corev1.Pod {
+	pod := r.NewPod()
+	pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{
+		Name:  "other",
+		Image: "example.com/other:latest",
+		Env: []corev1.EnvVar{
+			{
+				Name:  "OTHER",
+				Value: "some-other-value",
+			},
+		},
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: &[]bool{false}[0],
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{
+					"ALL",
+				},
+			},
+		},
+	})
+	return pod
+}
+
+func (r *AgentWebhookTestResources) NewPodJavaToolOptions() *corev1.Pod {
+	pod := r.NewPod()
+	container := &pod.Spec.Containers[0]
+	container.Env = append(container.Env,
+		corev1.EnvVar{
+			Name:  "JAVA_TOOL_OPTIONS",
+			Value: "-Dexisting=var",
+		})
+	return pod
+}
+
+func (r *AgentWebhookTestResources) NewPodJavaToolOptionsFrom() *corev1.Pod {
+	pod := r.NewPod()
+	container := &pod.Spec.Containers[0]
+	container.Env = append(container.Env,
+		corev1.EnvVar{
+			Name: "JAVA_TOOL_OPTIONS",
+			ValueFrom: &corev1.EnvVarSource{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "my-config",
+					},
+					Key:      "java-tool-options",
+					Optional: &[]bool{true}[0],
+				},
+			},
+		})
+	return pod
+}
+
+func (r *AgentWebhookTestResources) NewPodOtherNamespace(namespace string) *corev1.Pod {
+	pod := r.NewPod()
+	pod.Namespace = namespace
+	return pod
+}
+
+func (r *AgentWebhookTestResources) NewPodNoInjectLabel() *corev1.Pod {
+	pod := r.NewPod()
+	delete(pod.Labels, "com.redhat.insights.runtimes/inject-agent")
+	return pod
+}
+
+func (r *AgentWebhookTestResources) NewPodLogDebugLabel() *corev1.Pod {
+	pod := r.NewPod()
+	pod.Labels["com.redhat.insights.runtimes/log-debug"] = "true"
+	return pod
+}
+
+func (r *AgentWebhookTestResources) NewPodLogDebugLabelBad() *corev1.Pod {
+	pod := r.NewPod()
+	pod.Labels["com.redhat.insights.runtimes/log-debug"] = "not-a-bool"
+	return pod
+}
+
+func (r *AgentWebhookTestResources) NewPodContainerLabel() *corev1.Pod {
+	pod := r.NewPodMultiContainer()
+	pod.Labels["com.redhat.insights.runtimes/container"] = "other"
+	return pod
+}
+
+func (r *AgentWebhookTestResources) NewPodContainerBadLabel() *corev1.Pod {
+	pod := r.NewPodMultiContainer()
+	pod.Labels["com.redhat.insights.runtimes/container"] = "wrong"
+	return pod
+}
+
+func (r *AgentWebhookTestResources) NewPodJavaOptsVar() *corev1.Pod {
+	pod := r.NewPod()
+	pod.Labels["com.redhat.insights.runtimes/java-options-var"] = "SOME_OTHER_VAR"
+	return pod
+}
+
+type mutatedPodOptions struct {
+	debugLog         bool
+	javaOptionsName  string
+	javaOptionsValue string
+	namespace        string
+	image            string
+	pullPolicy       corev1.PullPolicy
+	scheme           string
+	resources        *corev1.ResourceRequirements
+	// Function to produce mutated container array
+	containersFunc func(*AgentWebhookTestResources, *mutatedPodOptions) []corev1.Container
+}
+
+func (r *AgentWebhookTestResources) setDefaultMutatedPodOptions(options *mutatedPodOptions) {
+	if len(options.namespace) == 0 {
+		options.namespace = r.Namespace
+	}
+	if len(options.image) == 0 {
+		options.image = "quay.io/ebaron/runtimes-agent-init:latest" // FIXME
+	}
+	if len(options.pullPolicy) == 0 {
+		options.pullPolicy = corev1.PullAlways
+	}
+	if len(options.javaOptionsName) == 0 {
+		options.javaOptionsName = "JAVA_TOOL_OPTIONS"
+	}
+	if options.resources == nil {
+		options.resources = &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("32Mi"),
+			},
+		}
+	}
+	options.scheme = "http"
+	if options.containersFunc == nil {
+		options.containersFunc = newMutatedContainers
+	}
+}
+
+func (r *AgentWebhookTestResources) NewMutatedPod() *corev1.Pod {
+	return r.newMutatedPod(&mutatedPodOptions{})
+}
+
+func (r *AgentWebhookTestResources) NewMutatedPodJavaToolOptions() *corev1.Pod {
+	return r.newMutatedPod(&mutatedPodOptions{
+		javaOptionsValue: "-Dexisting=var ",
+	})
+}
+
+func (r *AgentWebhookTestResources) NewMutatedPodCustomImage() *corev1.Pod {
+	return r.newMutatedPod(&mutatedPodOptions{
+		image:      "example.com/agent-init:2.0.0",
+		pullPolicy: corev1.PullIfNotPresent,
+	})
+}
+
+func (r *AgentWebhookTestResources) NewMutatedPodCustomDevImage() *corev1.Pod {
+	return r.newMutatedPod(&mutatedPodOptions{
+		image:      "example.com/agent-init:latest",
+		pullPolicy: corev1.PullAlways,
+	})
+}
+
+func (r *AgentWebhookTestResources) NewMutatedPodLogDebugLabel() *corev1.Pod {
+	return r.newMutatedPod(&mutatedPodOptions{
+		debugLog: true,
+	})
+}
+
+func (r *AgentWebhookTestResources) NewMutatedPodMultiContainer() *corev1.Pod {
+	return r.newMutatedPod(&mutatedPodOptions{
+		containersFunc: newMutatedMultiContainers,
+	})
+}
+
+func (r *AgentWebhookTestResources) NewMutatedPodContainerLabel() *corev1.Pod {
+	return r.newMutatedPod(&mutatedPodOptions{
+		containersFunc: newMutatedMultiContainersLabel,
+	})
+}
+
+func (r *AgentWebhookTestResources) NewMutatedPodJavaOptsVarLabel() *corev1.Pod {
+	return r.newMutatedPod(&mutatedPodOptions{
+		javaOptionsName: "SOME_OTHER_VAR",
+	})
+}
+
+func (r *AgentWebhookTestResources) newMutatedPod(options *mutatedPodOptions) *corev1.Pod {
+	r.setDefaultMutatedPodOptions(options)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "insights-agent-webhook-test",
+			Namespace: options.namespace,
+			Labels: map[string]string{
+				"com.redhat.insights.runtimes/inject-agent": "true",
+			},
+		},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{
+					Name:            "runtimes-agent-init",
+					Image:           options.image,
+					ImagePullPolicy: options.pullPolicy,
+					Command:         []string{"cp", "-v", "/agent/runtimes-agent.jar", "/tmp/rh-runtimes-insights/runtimes-agent.jar"},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "runtimes-agent-init",
+							MountPath: "/tmp/rh-runtimes-insights",
+						},
+					},
+					SecurityContext: &corev1.SecurityContext{
+						RunAsNonRoot: &[]bool{true}[0],
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{
+								"ALL",
+							},
+						},
+					},
+					Resources: *options.resources,
+				},
+			},
+			Containers: options.containersFunc(r, options),
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot: &[]bool{true}[0],
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: "runtimes-agent-init",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{
+							SizeLimit: &[]resource.Quantity{resource.MustParse("50Mi")}[0],
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return pod
+}
+
+func newMutatedContainers(r *AgentWebhookTestResources, options *mutatedPodOptions) []corev1.Container {
+	containers := r.NewPodMultiContainer().Spec.Containers
+	return []corev1.Container{*r.newMutatedContainer(&containers[0], options)}
+}
+
+func newMutatedMultiContainers(r *AgentWebhookTestResources, options *mutatedPodOptions) []corev1.Container {
+	containers := r.NewPodMultiContainer().Spec.Containers
+	return []corev1.Container{*r.newMutatedContainer(&containers[0], options), containers[1]}
+}
+
+func newMutatedMultiContainersLabel(r *AgentWebhookTestResources, options *mutatedPodOptions) []corev1.Container {
+	containers := r.NewPodMultiContainer().Spec.Containers
+	return []corev1.Container{containers[0], *r.newMutatedContainer(&containers[1], options)}
+}
+
+func (r *AgentWebhookTestResources) newMutatedContainer(original *corev1.Container, options *mutatedPodOptions) *corev1.Container {
+	svc := r.NewInsightsProxyService()
+	debugLogging := ""
+	if options.debugLog {
+		debugLogging = ";debug=true"
+	}
+	agentArgLine := fmt.Sprintf("-javaagent:'/tmp/rh-runtimes-insights/runtimes-agent.jar=name=$(RHT_INSIGHTS_JAVA_AGENT_POD_NAME);base_url=http://%s.%s.svc:8080;pod_name=$(RHT_INSIGHTS_JAVA_AGENT_POD_NAME);pod_namespace=$(RHT_INSIGHTS_JAVA_AGENT_POD_NAMESPACE);token=unused%s'",
+		svc.Name, svc.Namespace, debugLogging)
+	prependEnv := append([]corev1.EnvVar{
+		{
+			Name: "RHT_INSIGHTS_JAVA_AGENT_POD_NAME",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					APIVersion: "v1",
+					FieldPath:  "metadata.name",
+				},
+			},
+		},
+		{
+			Name: "RHT_INSIGHTS_JAVA_AGENT_POD_NAMESPACE",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					APIVersion: "v1",
+					FieldPath:  "metadata.namespace",
+				},
+			},
+		},
+	}, original.Env...)
+	container := &corev1.Container{
+		Name:  original.Name,
+		Image: original.Image,
+		Env: append(prependEnv, corev1.EnvVar{
+			Name:  options.javaOptionsName,
+			Value: options.javaOptionsValue + agentArgLine,
+		}),
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: &[]bool{false}[0],
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{
+					"ALL",
+				},
+			},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      "runtimes-agent-init",
+				MountPath: "/tmp/rh-runtimes-insights",
+				ReadOnly:  true,
+			},
+		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("32Mi"),
+			},
+		},
+	}
+
+	return container
+}

--- a/internal/webhooks/webhooks_suite_test.go
+++ b/internal/webhooks/webhooks_suite_test.go
@@ -1,0 +1,144 @@
+// Copyright The Cryostat Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhooks_test
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/RedHatInsights/runtimes-inventory-operator/internal/controller/test"
+	"github.com/RedHatInsights/runtimes-inventory-operator/internal/webhooks"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+
+	//+kubebuilder:scaffold:imports
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var cfg *rest.Config
+var k8sClient client.Client
+var testEnv *envtest.Environment
+var ctx context.Context
+var cancel context.CancelFunc
+var k8sScheme *runtime.Scheme
+var agentWebhookConfig *webhooks.AgentWebhookConfig
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Agent Webhook Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: false,
+		WebhookInstallOptions: envtest.WebhookInstallOptions{
+			Paths: []string{filepath.Join("..", "..", "config", "webhook")},
+		},
+	}
+
+	var err error
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	k8sScheme = runtime.NewScheme()
+	err = scheme.AddToScheme(k8sScheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = admissionv1beta1.AddToScheme(k8sScheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	//+kubebuilder:scaffold:scheme
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: k8sScheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	// start webhook server using Manager
+	webhookInstallOptions := &testEnv.WebhookInstallOptions
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: k8sScheme,
+		WebhookServer: webhook.NewServer(webhook.Options{
+			Host:    webhookInstallOptions.LocalServingHost,
+			Port:    webhookInstallOptions.LocalServingPort,
+			CertDir: webhookInstallOptions.LocalServingCertDir,
+		}),
+		LeaderElection: false,
+		Metrics:        metricsserver.Options{BindAddress: "0"},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	agentWebhookConfig = &webhooks.AgentWebhookConfig{
+		OSUtils: test.NewTestOSUtils(&test.TestUtilsConfig{}),
+	}
+	agentWebhook := webhooks.NewAgentWebhook(agentWebhookConfig)
+	err = agentWebhook.SetupWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
+	//+kubebuilder:scaffold:webhook
+
+	go func() {
+		defer GinkgoRecover()
+		err = mgr.Start(ctx)
+		Expect(err).NotTo(HaveOccurred())
+	}()
+
+	// wait for the webhook server to get ready
+	dialer := &net.Dialer{Timeout: time.Second}
+	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
+	Eventually(func() error {
+		conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})
+		if err != nil {
+			return err
+		}
+		conn.Close()
+		return nil
+	}).Should(Succeed())
+
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/pkg/insights/setup.go
+++ b/pkg/insights/setup.go
@@ -178,7 +178,7 @@ func (i *InsightsIntegration) deleteConfigMap(ctx context.Context) error {
 func (i *InsightsIntegration) getProxyURL() *url.URL {
 	return &url.URL{
 		Scheme: "http", // TODO add https support
-		Host: fmt.Sprintf("%s.%s.svc.cluster.local:%d", common.ProxyServiceName(i.opName), i.opNamespace,
+		Host: fmt.Sprintf("%s.%s.svc:%d", common.ProxyServiceName(i.opName), i.opNamespace,
 			common.ProxyServicePort),
 	}
 }

--- a/pkg/insights/setup_test.go
+++ b/pkg/insights/setup_test.go
@@ -105,7 +105,7 @@ var _ = Describe("InsightsIntegration", func() {
 				result, err := t.integration.Setup()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).ToNot(BeNil())
-				Expect(result.String()).To(Equal(fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", t.NewInsightsProxyService().Name, t.Namespace)))
+				Expect(result.String()).To(Equal(fmt.Sprintf("http://%s.%s.svc:8080", t.NewInsightsProxyService().Name, t.Namespace)))
 			})
 
 			It("should create config map", func() {


### PR DESCRIPTION
This adds a pod mutation webhook that injects the Insights Java Agent using an init container when pods are created with a `com.redhat.insights.agent/inject-agent: "true"` label. There's some additional Operator SDK scaffolding for the webhook and use of cert-manager to secure it.

Besides from the mandatory label to inject the agent, there are additional optional labels to control how the webhook mutates the pod:
* `com.redhat.insights.agent/container`: by default the webhook injects the agent into the pod's first container, this behaviour can be altered by naming a different container with this label
* `com.redhat.insights.agent/java-options-var`: the agent is normally injected using the `JAVA_TOOL_OPTIONS` environment variable. This label allows users to specify a different environment variable. This is particularly useful for Wildfly, which should use `MODULE_OPTS`.
* `com.redhat.insights.agent/log-debug`: setting this to true enables debug logging in the agent

To test:
1. Deploy the operator (and cert-manager):
    ```
    make cert_manager deploy IMG=quay.io/ebaron/runtimes-inventory-operator:$(git branch --show-current)-05
    ```
1. Override the init container image to use my build
    ```
    oc set env deploy runtimes-inventory-operator-controller-manager RELATED_IMAGE_AGENT_INIT="quay.io/ebaron/runtimes-agent-init:latest"
    ```
1. Try a Quarkus-based sample app
    a. Deploy it:
      ```
      oc new-app --docker-image=quay.io/redhat-java-monitoring/quarkus-cryostat-agent --name=quarkus-test
      ```
    b. Create a patch file with the following:
      ```yaml
      spec:
        template:
          metadata:
            labels:
              com.redhat.insights.runtimes/inject-agent: "true"
              com.redhat.insights.runtimes/log-debug: "true"
      ```
    c. Check the logs for the payload to be sent:
      ```
      oc logs -f deploy/quarkus-test | grep Payload
      Defaulted container "quarkus-test" out of: quarkus-test, runtimes-agent-init (init)
      2025-06-23 17:46:52:757 +0000 [pool-1-thread-1] DEBUG com.redhat.insights.agent.AgentLogger - Red Hat Insights - Payload was accepted for processing
      ```
1. Try a Wildfly sample app
    a. Deploy it:
      ```
      oc new-app --docker-image=quay.io/redhat-java-monitoring/wildfly-28-cryostat-agent --name=wildfly-test
      ```
    b. Create a patch file with the following:
      ```yaml
      spec:
        template:
          metadata:
            labels:
              com.redhat.insights.runtimes/inject-agent: "true"
              com.redhat.insights.runtimes/log-debug: "true"
              com.redhat.insights.runtimes/java-options-var: MODULE_OPTS
      ```
    c. Check the logs for the payload to be sent:
      ```
      oc logs -f deploy/wildfly-test | grep Payload
      Defaulted container "wildfly-test" out of: wildfly-test, runtimes-agent-init (init)
      17:44:08,405 ERROR [stderr] (pool-1-thread-1) [pool-1-thread-1] DEBUG com.redhat.insights.agent.AgentLogger - Red Hat Insights - Payload was accepted for processing
      ```