### PR TITLE
build(bundle): use runtimes-inventory-operator prefix

### DIFF
--- a/bundle/manifests/runtimes-inventory-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/runtimes-inventory-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2025-07-08T21:30:33Z"
+    createdAt: "2025-08-13T20:56:09Z"
     operators.operatorframework.io/builder: operator-sdk-v1.39.2
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   labels:
@@ -103,7 +103,7 @@ spec:
                 - name: RELATED_IMAGE_INSIGHTS_PROXY
                   value: registry.redhat.io/3scale-amp2/apicast-gateway-rhel8:3scale2.15
                 - name: USER_AGENT_PREFIX
-                  value: cryostat-operator/0.0.0
+                  value: runtimes-inventory-operator/0.0.0
                 image: controller:latest
                 livenessProbe:
                   httpGet:
@@ -140,6 +140,8 @@ spec:
                   readOnly: true
               securityContext:
                 runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
               serviceAccountName: runtimes-inventory-operator-controller-manager
               terminationGracePeriodSeconds: 10
               volumes:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -56,13 +56,8 @@ spec:
       #               - linux
       securityContext:
         runAsNonRoot: true
-        # TODO(user): For common cases that do not require escalating privileges
-        # it is recommended to ensure that all your Pods/Containers are restrictive.
-        # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
-        # Please uncomment the following code if your project does NOT have to work on old Kubernetes
-        # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
-        # seccompProfile:
-        #   type: RuntimeDefault
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -87,9 +82,8 @@ spec:
           value: registry.redhat.io/insights-runtimes-tech-preview/runtimes-agent-init-rhel9:latest
         - name: RELATED_IMAGE_INSIGHTS_PROXY
           value: registry.redhat.io/3scale-amp2/apicast-gateway-rhel8:3scale2.15
-        # FIXME temp
         - name: USER_AGENT_PREFIX
-          value: cryostat-operator/0.0.0
+          value: runtimes-inventory-operator/0.0.0
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
This PR replaces the UHC Auth Proxy placeholder prefix with a proper `runtimes-inventory-operator` prefix, after https://github.com/RedHatInsights/uhc-auth-proxy/pull/249.

1. Run the bundle of this PR I built: `./bin/operator-sdk run bundle quay.io/ebaron/runtimes-inventory-operator-bundle:rio-prefix-01`
1. Try a Quarkus-based sample app
    a. Deploy it:
      ```
      oc new-app --docker-image=quay.io/redhat-java-monitoring/quarkus-cryostat-agent --name=quarkus-test
      ```
    b. Create a patch file with the following:
      ```yaml
      spec:
        template:
          metadata:
            labels:
              com.redhat.insights.runtimes/inject-agent: "true"
              com.redhat.insights.runtimes/log-debug: "true"
      ```
   c. Patch the deployment: `oc patch deploy quarkus-test --patch-file /path/to/patch`
   d. Check the logs for the payload to be sent:
      ```
      oc logs -f deploy/quarkus-test | grep Payload
      Defaulted container "quarkus-test" out of: quarkus-test, runtimes-agent-init (init)
      2025-06-23 17:46:52:757 +0000 [pool-1-thread-1] DEBUG com.redhat.insights.agent.AgentLogger - Red Hat Insights - 