### PR TITLE
chore(oci): use UBI9 and GA agent init image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/go-toolset:latest as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:latest as builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -28,20 +28,7 @@ RUN GOEXPERIMENT=strictfipsruntime \
     GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
     go build -a -o /opt/app-root/manager -tags strictfipsruntime cmd/main.go
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
-
-LABEL com.redhat.component="runtimes-inventory-rhel8-operator-container"
-LABEL name="insights-runtimes-tech-preview/runtimes-inventory-rhel8-operator"
-LABEL maintainer="Red Hat Insights for Runtimes"
-LABEL summary="Operator support for Runtimes Inventory"
-LABEL description="A reusable component for Red Hat operators managing Java workloads. \
-This component allows these operators to more easily integrate their workloads into \
-the Red Hat Insights Runtimes Inventory."
-LABEL io.k8s.description="A reusable component for Red Hat operators managing Java workloads. \
-This component allows these operators to more easily integrate their workloads into \
-the Red Hat Insights Runtimes Inventory."
-LABEL io.k8s.display-name="Runtimes Inventory Operator"
-LABEL io.openshift.tags="insights,java,openshift"
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 COPY --from=builder /opt/app-root/manager .
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.1-dev
+VERSION ?= 1.0.0-dev
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/runtimes-inventory-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/runtimes-inventory-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2025-08-13T20:56:09Z"
+    createdAt: "2025-09-05T20:05:51Z"
     operators.operatorframework.io/builder: operator-sdk-v1.39.2
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   labels:
@@ -13,7 +13,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: runtimes-inventory-operator.v0.0.1-dev
+  name: runtimes-inventory-operator.v1.0.0-dev
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -99,11 +99,11 @@ spec:
                 - name: INSIGHTS_BACKEND_DOMAIN
                   value: console.redhat.com
                 - name: RELATED_IMAGE_AGENT_INIT
-                  value: registry.redhat.io/insights-runtimes-tech-preview/runtimes-agent-init-rhel9:latest
+                  value: registry.redhat.io/insights-runtimes/runtimes-agent-init-rhel9:latest
                 - name: RELATED_IMAGE_INSIGHTS_PROXY
                   value: registry.redhat.io/3scale-amp2/apicast-gateway-rhel8:3scale2.15
                 - name: USER_AGENT_PREFIX
-                  value: runtimes-inventory-operator/0.0.0
+                  value: runtimes-inventory-operator/1.0.0
                 image: controller:latest
                 livenessProbe:
                   httpGet:
@@ -244,11 +244,11 @@ spec:
     name: Red Hat
     url: https://www.redhat.com
   relatedImages:
-  - image: registry.redhat.io/insights-runtimes-tech-preview/runtimes-agent-init-rhel9:latest
+  - image: registry.redhat.io/insights-runtimes/runtimes-agent-init-rhel9:latest
     name: agent-init
   - image: registry.redhat.io/3scale-amp2/apicast-gateway-rhel8:3scale2.15
     name: insights-proxy
-  version: 0.0.1-dev
+  version: 1.0.0-dev
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -79,11 +79,11 @@ spec:
         - name: INSIGHTS_BACKEND_DOMAIN
           value: console.redhat.com
         - name: RELATED_IMAGE_AGENT_INIT
-          value: registry.redhat.io/insights-runtimes-tech-preview/runtimes-agent-init-rhel9:latest
+          value: registry.redhat.io/insights-runtimes/runtimes-agent-init-rhel9:latest
         - name: RELATED_IMAGE_INSIGHTS_PROXY
           value: registry.redhat.io/3scale-amp2/apicast-gateway-rhel8:3scale2.15
         - name: USER_AGENT_PREFIX
-          value: runtimes-inventory-operator/0.0.0
+          value: runtimes-inventory-operator/1.0.0
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/internal/webhooks/pod_mutator.go
+++ b/internal/webhooks/pod_mutator.go
@@ -54,7 +54,7 @@ const (
 	podNameEnvVar            = "RHT_INSIGHTS_JAVA_AGENT_POD_NAME"
 	podNamespaceEnvVar       = "RHT_INSIGHTS_JAVA_AGENT_POD_NAMESPACE"
 	debugEnvVar              = "RHT_INSIGHTS_JAVA_AGENT_DEBUG"
-	defaultAgentInitImageTag = "registry.redhat.io/insights-runtimes-tech-preview/runtimes-agent-init-rhel9:latest"
+	defaultAgentInitImageTag = "registry.redhat.io/insights-runtimes/runtimes-agent-init-rhel9:latest"
 	agentMaxSizeBytes        = "50Mi"
 	agentInitCpuRequest      = "10m"
 	agentInitMemoryRequest   = "32Mi"

--- a/internal/webhooks/test/resources.go
+++ b/internal/webhooks/test/resources.go
@@ -177,7 +177,7 @@ func (r *AgentWebhookTestResources) setDefaultMutatedPodOptions(options *mutated
 		options.namespace = r.Namespace
 	}
 	if len(options.image) == 0 {
-		options.image = "registry.redhat.io/insights-runtimes-tech-preview/runtimes-agent-init-rhel9:latest"
+		options.image = "registry.redhat.io/insights-runtimes/runtimes-agent-init-rhel9:latest"
 	}
 	if len(options.pullPolicy) == 0 {
 		options.pullPolicy = corev1.PullAlways


### PR DESCRIPTION
This PR handles a few cleanup tasks:
* Switch from UBI8 to UBI9
* Removes some downstream labels from the Dockerfile after moving the Konflux build downstream
* Use the GA repository for the agent init image
* Update some version numbers