### PR TITLE
fix(setup): don't crash if Insights is disabled

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,7 +21,6 @@ import (
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 
-	"github.com/RedHatInsights/runtimes-inventory-operator/internal/webhooks"
 	"github.com/RedHatInsights/runtimes-inventory-operator/pkg/insights"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
@@ -175,19 +174,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	insightsURL, err := insights.NewInsightsIntegration(mgr,
+	err = insights.NewInsightsIntegration(mgr,
 		operatorName, operatorNamespace, userAgentPrefix, &setupLog).Setup()
 	if err != nil {
 		setupLog.Error(err, "failed to set up Insights integration")
-	} else {
-		setupLog.Info("Insights proxy set up", "url", insightsURL.String())
-		agentWebhook := webhooks.NewAgentWebhook(&webhooks.AgentWebhookConfig{
-			InsightsURL: insightsURL,
-		})
-		if err = agentWebhook.SetupWebhookWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "Pod")
-			os.Exit(1)
-		}
+		os.Exit(1)
 	}
 	//+kubebuilder:scaffold:builder
 

--- a/internal/controller/test/manager.go
+++ b/internal/controller/test/manager.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
 type FakeManager struct {
@@ -76,4 +77,8 @@ func (m *FakeManager) SetFields(interface{}) error {
 
 func (m *FakeManager) Add(manager.Runnable) error {
 	return nil
+}
+
+func (m *FakeManager) GetWebhookServer() webhook.Server {
+	return &webhook.DefaultServer{}
 }


### PR DESCRIPTION
This PR fixes a crash when Insights is disabled using the `INSIGHTS_ENABLED` environment variable. It also moves as much of the logic as possible from main.go to setup.go, where it can be more easily tested.